### PR TITLE
Delete members on cascade

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,6 @@
 class Organization < ActiveRecord::Base
   validates_uniqueness_of :name
-  has_many :members
+  has_many :members, dependent: :destroy
   has_many :users, -> { order "members.created_at DESC" }, through: :members
 
   has_one :account, as: :accountable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ActiveRecord::Base
   validates :email, presence: true, uniqueness: true
   # validates :gender, presence: true, inclusion: {in: GENDERS}
 
-  has_many :members
+  has_many :members, dependent: :destroy
   accepts_nested_attributes_for :members
   has_many :organizations, through: :members
   has_many :accounts, through: :members


### PR DESCRIPTION
En relación a https://redbooth.com/a/#!/notifications/638099/tasks/15129412

Veo que hay otros `has_many` y `has_one` sin `dependent`, no estoy seguro si es a propósito o falta definir la política: destroy, nullify, ... lo podemos pensar, pero estaria bien con el fin de mantener la DB limpia.

En este caso he elegido `dependent: :destroy`, para que llame los callbacks de las instancias q se borren.  
