### PR TITLE
run Travis CI against Ruby 2.1.X & fix test suite [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
-rvm: 2.1
+rvm:
+  - 2.1
 env: DATABASE_URL=postgres://postgres@localhost/timeoverflow_test
 before_script:
   - psql -c 'create database timeoverflow_test;' -U postgres
+  - RAILS_ENV=test bundle exec rake db:migrate


### PR DESCRIPTION
Desde que existe código que depende de Ruby 2+ (https://github.com/coopdevs/timeoverflow/blob/master/app/controllers/posts_controller.rb#L8), deberíamos correr Travis con esa version.

La suite test sigue sin funcionar, pero de momento esto hará falta seguro.
