### PR TITLE
HAML does not like newlines

### DIFF
--- a/app/views/offers/edit.html.haml
+++ b/app/views/offers/edit.html.haml
@@ -3,8 +3,7 @@
   %small
     = t ".edit"
 
-= render partial: "shared/post_form", locals: { post: @offer,
-                                                label_button: t(".submit") }
+= render partial: 'shared/post_form', locals: { post: @offer, label_button: t(".submit") }
 
 :javascript
   $("#offer_tag_list").tagsManager();


### PR DESCRIPTION
In this case one could have written

```
render 'shared/post_form', post: @offer, label_button: t(".submit")
```

that is shorter, anyway a long line is not a very big problem here
