### PR TITLE
Rails already defines a PDF mime type.

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,4 +2,3 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
-Mime::Type.register "application/pdf", :pdf


### PR DESCRIPTION
```
$ rails c
>> Mime::EXTENSION_LOOKUP.select { |k, _| k == 'pdf' }
=> {"pdf"=>#<Mime::Type:0x007fb0c2414ba8 @synonyms=[], @symbol=:pdf, @string="application/pdf">}
```

https://github.com/rails/rails/blob/v4.2.0/actionpack/lib/action_dispatch/http/mime_types.rb#L32

Warning on boot:

```
/Users/markets/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/actionpack-4.2.0/lib/action_dispatch/http/mime_type.rb:163: warning: already initialized constant Mime::PDF
/Users/markets/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/actionpack-4.2.0/lib/action_dispatch/http/mime_type.rb:163: warning: previous definition of PDF was here
```