### PR TITLE
Speed up TravisCI database setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
 language: ruby
-
+sudo: false
+cache: bundler
+bundler_args: '--without production development'
 rvm:
   - 2.2.2
-
 env: DATABASE_URL=postgres://postgres@localhost/timeoverflow_test
-
 before_script:
-  - psql -c 'create database timeoverflow_test;' -U postgres
-  - RAILS_ENV=test bundle exec rake db:migrate
-
-sudo: false
-
-cache: bundler
-
+  - bundle exec rake db:setup
 services:
   - elasticsearch


### PR DESCRIPTION
Use db:setup db:migrate instead of just db:migrate
Don't install production & development gems
Configure db from database.yml

Let's see if this runs faster than before..
BTW.. that's how I use to work with the `database.yml`