### PR TITLE
Rails complains when the `database.url` key is not an url

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -14,4 +14,5 @@ test:
   database: <%= ENV.fetch('DATABASE_NAME', 'timeoverflow_test') %>
 
 production:
-  url: <%= ENV.fetch('DATABASE_URL', 'Set DATABASE_URL environment variable') %>
+  # Set DATABASE_URL environment variable
+  url: <%= ENV.fetch('DATABASE_URL', 'null') %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 # If you want to change this file, please keep the changes in your working
 # copy by using
 #
-#     git update-index --assume-unchanged config/database.yml
+#     git update-index --skip-worktree config/database.yml
 #
 
 defaults: &defaults

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,8 +1,8 @@
 defaults: &defaults
   adapter: postgresql
-  host: <%= ENV.fetch('DATABASE_HOST', 'localhost') %>
-  username: <%= ENV.fetch('DATABASE_USER', 'null') %>
-  password: <%= ENV.fetch('DATABASE_PASSWORD', 'null') %>
+  host: <%= ENV['DATABASE_HOST'] %>  # default is localhost
+  username: <%= ENV['DATABASE_USER'] %>  # default is null
+  password: <%= ENV['DATABASE_PASSWORD'] %>  # default is null
   encoding: utf8
 
 development:
@@ -15,4 +15,4 @@ test:
 
 production:
   # Set DATABASE_URL environment variable
-  url: <%= ENV.fetch('DATABASE_URL', 'null') %>
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,12 @@
 #
 #     git update-index --skip-worktree config/database.yml
 #
+# or just use DATABASE_URL, in which case Rails will happily skip the whole
+# file.
+#
+# See https://github.com/coopdevs/timeoverflow/wiki/Keeping-your-local-files
+# for more information
+#
 
 defaults: &defaults
   adapter: postgresql

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,3 +1,9 @@
+# If you want to change this file, please keep the changes in your working
+# copy by using
+#
+#     git update-index --assume-unchanged config/database.yml
+#
+
 defaults: &defaults
   adapter: postgresql
   host: <%= ENV['DATABASE_HOST'] %>  # default is localhost


### PR DESCRIPTION
This is the output of `rake db:migrate:status` (for instance) whatever the environment is:
```
rake aborted!
URI::InvalidURIError: bad URI(is not URI?): Set DATABASE_URL environment variable
/.../config/environment.rb:5:in `<top (required)>'
Tasks: TOP => db:migrate:status => environment
(See full trace by running task with --trace)
```