### PR TITLE
Switch to haml_lint since haml-lint does not exist anymore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ group :development do
   gem "binding_of_caller"
   gem "better_errors"
   gem "rubocop"
-  gem "haml-lint"
   gem 'web-console', '2.1.3'
   gem 'capistrano', '~> 3.1'
   gem 'capistrano-rails', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,10 +155,6 @@ GEM
       activesupport (>= 4.1.0)
     haml (4.1.0.beta.1)
       tilt
-    haml-lint (0.10.0)
-      haml (~> 4.0)
-      rubocop (>= 0.25.0)
-      sysexits (~> 1.1)
     haml-rails (0.6.0)
       actionpack (>= 4.0.1)
       activesupport (>= 4.0.1)
@@ -345,7 +341,6 @@ GEM
     sshkit (1.8.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
-    sysexits (1.2.0)
     temple (0.7.5)
     thin (1.6.3)
       daemons (~> 1.0, >= 1.0.9)
@@ -403,7 +398,6 @@ DEPENDENCIES
   fabrication
   faker
   foreman
-  haml-lint
   haml-rails
   has_scope
   high_voltage (~> 2.1.0)


### PR DESCRIPTION
### WAT
We just discovered that the gem changed its name :sob: 
https://github.com/brigade/haml-lint/issues/133

### GIF
![](https://media.giphy.com/media/5saWnCIJL7nmU/giphy.gif)