### PR TITLE
Fix inactive user statistics

### DIFF
--- a/app/views/statistics/statistics_inactive_users.html.haml
+++ b/app/views/statistics/statistics_inactive_users.html.haml
@@ -10,9 +10,9 @@
           %th= t ".last_movement"
       %tbody
       / Por días sin movimientos
-      - @members.includes(:account).sort_by(&:days_without_swaps).reverse.map{ |a| a unless a.days_without_swaps.zero? }.compact.each do |mem|
+      - @members.includes(:account).sort_by(&:days_without_swaps).reverse.compact.each do |mem|
         %tr
           %td= mem.member_uid
           %td= link_to mem.user.username, mem.user
           %td= mem.days_without_swaps
-          %td= (mem.account.balance.blank? || mem.account.balance.zero?) ? t(".no_movements") : l(mem.account.updated_at, format: :long)
+          %td= (mem.account.updated_at == mem.account.created_at) ? t(".no_movements") : l(mem.account.updated_at, format: :long)


### PR DESCRIPTION
Este listado de miembros muestra los miembros que hace más días que no intercambian. Marcaba como  "sin intercambios" a miembros que tenían balance = 0 aunque hubiesen hecho intercambios.