### PR TITLE
Fix description show in user detail

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -64,7 +64,7 @@
         - @member.offers.active.each do |post|
           %tr
             %td= link_to post, post
-            %td= post.description
+            %td= strip_tags(post.rendered_description.to_html)
             %td
               %a{href: give_time_user_path(@user, offer: post.id), title: t("global.give_time")}
                 %span.glyphicon.glyphicon-time
@@ -82,7 +82,7 @@
         - @member.inquiries.active.each do |post|
           %tr
             %td= link_to post, post
-            %td= post.description
+            %td= strip_tags(post.rendered_description.to_html)
 
 .row
   .col-sm-4


### PR DESCRIPTION
Esto arregla que al ver el detalle de un usuario en descripción de ofertas y demandas no salga código markdown