### PR TITLE
Change posts dates from created to updated date

### DIFF
--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -10,7 +10,7 @@
         </h3>
       </div>
       <div class="panel-body">
-        <%= l post.created_at.to_date, format: :long %>
+        <%= l post.updated_at.to_date, format: :long %>
         <p></p>
         <%= link_to get_index_path(post, cat: post.category) do %>
           <%= glyph :folder_open %>

--- a/app/views/shared/_posts.html.erb
+++ b/app/views/shared/_posts.html.erb
@@ -18,9 +18,11 @@
           <%= glyph :tag %>
           <%= link_to tag, get_index_path(post,tag: tag) %>
         <% end %>
-        <span class="pull-right">
-          <%= l post.created_at.to_date, format: :long %>
-        </span>
+        <% if post.type == "Inquiry" %>
+          <span class="pull-right">
+            <%= l post.updated_at.to_date, format: :long %>
+          </span>
+        <% end %>
       </small>
     </p>
   </div>


### PR DESCRIPTION
En el listado de post y en el el detalle se mostraba la fecha de creación de las ofertas/demandas, tienes más sentido mostrar la fecha de actualización

Por otro lado solo se debe mostrar la fecha en el listado de demandas y no de ofertas.