### PR TITLE
Remove Robohash for avatars

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,14 +5,14 @@ module ApplicationHelper
   TEXT_SUCCESS = 'text-success'.freeze
   TEXT_DANGER = 'text-danger'.freeze
 
-  # from https://robohash.org
+  # from gravatar
   def avatar_url(user, size = 32)
     gravatar_id = Digest::MD5::hexdigest(user.email).downcase
     gravatar_options = Hash[set: "set1",
                             gravatar: "hashed",
                             size: "#{size}x#{size}"]
-    "https://robohash.org/#{gravatar_id}.png?" +
-      "#{Rack::Utils.build_query(gravatar_options)}"
+    "https://www.gravatar.com/avatar/#{gravatar_id}.png?" +
+      "#{Rack::Utils.build_query(gravatar_options)}&d=identicon"
   end
 
   def mdash


### PR DESCRIPTION
A los usuarios no les gustan los robotitos. Además con robohash hay días que el servicio se cae y timeoverflow va muy lento además de que no se cargan los avatares. Volvemos a gravatar.

Por defecto los usuarios que no tienen avatar les ponemos una imagen geométrica hecha a partir del hash, (d=identicon)

![](https://www.gravatar.com/avatar/b58996c504c5638798eb6b511e6f49af.png?set=set1&gravatar=hashed&size=160x160&d=identicon)