### PR TITLE
Fix form submit and style classes

### DIFF
--- a/app/views/statistics/statistics_global_activity.html.erb
+++ b/app/views/statistics/statistics_global_activity.html.erb
@@ -2,7 +2,7 @@
   <%= t 'global.statistics' %>: <%= t '.global_activity' %>
 </h1>
 <div>
-  <div class="panel panel-default">
+  <div class="panel panel-default" ng_controller="">
     <div class="panel-body">
       <ul class="nav nav-pills statistics">
         <li>
@@ -25,7 +25,7 @@
         </li>
       </ul>
     </div>
-    <form class="navbar-form navbar-right">
+    <form class="form-inline text-right">
       <div class="form-group">
         <input class="form-control"
                id="datepicker_from"


### PR DESCRIPTION
El formulario de filtro entre fechas no funcionaba, he comparado con versiones anteriores y faltaba ng_controller="" también he cambiado las class del form para que se viera bien.