### PR TITLE
Force 100% width to select2 jQuery

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -394,6 +394,11 @@ label[required]::after{
   margin: 0 auto;
 }
 
+//fix select2 100px
+.select2-container {
+  width: 100% !important;
+}
+
 .navbar-form {
   padding: 0;
   background-color: transparent;


### PR DESCRIPTION
Hace tiempo que varios Bancos de Tiempo me comentan este problema, por algún motivo el select2 ponía un width de 100px en lugar de 100% como solución rápida con css se puede forzar a que sea 100%
![2017-02-27-174911_1600x900_scrot](https://cloud.githubusercontent.com/assets/2297137/23370682/c2cc0336-fd15-11e6-8b94-d2c814ed8400.png)
