### PR TITLE
Restore visit previous URL stored in session

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,9 +34,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # Store last url, this is needed for post-login redirect to whatever the
+  # user last visited.
+  # See #after_sign_in_path_for method in this class and Devise documentation:
+  # https://github.com/plataformatec/devise/wiki/How-To%3a-Redirect-to-a-specific-page-on-successful-sign-in-out
   def store_location
-    # store last url - this is needed for post-login redirect to whatever the
-    # user last visited.
     return unless request.get?
     paths = ["/", "/users/sign_in", "/users/sign_up", "/users/password/new",
              "/users/password/edit", "/users/confirmation", "/users/sign_out"]
@@ -45,12 +47,15 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # Returns a string with the path where the user will be redirected
+  # after the sign in.
+  #
+  # @return [String]
   def after_sign_in_path_for(user)
-    if user.members.present?
-      users_path
-    else
-      page_path("about")
-    end
+    return session[:previous_url] if session[:previous_url]
+    return users_path if user.members.present?
+
+    page_path("about")
   end
 
   private


### PR DESCRIPTION
Some time ago we introduced Devise restore previous URL after sign in with https://github.com/coopdevs/timeoverflow/pull/148

Later we tried to fix some issue with https://github.com/coopdevs/timeoverflow/commit/ed873236786e1e930b95f6baa326151034e9fdf5 and https://github.com/coopdevs/timeoverflow/commit/601aece453413c34cf70f223724b18ca608e2fdc

The result is that we removed that Devise functionality, but we don't have enough context to say why since the mentioned commits give no information about the issues.

Since users use posts links from emails they are always redirected to `/members` after login instead of the post they where looking for.

With this PR we re-introduce the functionality and we'll see if we'll encounter again those issue. 🙏 