### PR TITLE
Correctly ignore ctags' .tags and tags files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ sgemset
 .metadata
 
 # CTAGS generated files
-.tags*
+.tags
+tags
 
 .localeapp


### PR DESCRIPTION
Teníamos ignorado `.tags*` pero este no parece ser un nombre de archivo habitual de ctags. Ver https://github.com/github/gitignore/blob/master/Global/Tags.gitignore.

Además esto no ignora el archivo `tags` (almenos es el que me genera a mi ctags).