### PR TITLE
Remove devise session flash messages

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,14 @@
+class SessionsController < Devise::SessionsController
+
+  # POST /resource/sign_in
+  def create
+    super
+    flash.delete(:notice)
+  end
+
+  # DELETE /resource/sign_out
+  def destroy
+    super
+    flash.delete(:notice)
+  end
+end

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -242,8 +242,6 @@ ca:
       new:
         remember_me: Recorda'm
         sign_in: Entrar
-      signed_in: 
-      signed_out: 
     shared:
       links:
         didnt_receive_confirmation_instructions: Tornar a enviar correu de confirmació

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,8 +242,6 @@ en:
       new:
         remember_me: Remember me
         sign_in: Login
-      signed_in: 
-      signed_out: 
     shared:
       links:
         didnt_receive_confirmation_instructions: Resend confirmation email

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -245,8 +245,6 @@ es:
       new:
         remember_me: Recordarme
         sign_in: Entrar
-      signed_in: 
-      signed_out: 
       user:
         signed_in: 
     shared:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -245,8 +245,6 @@ pt-BR:
       new:
         remember_me: Lembrar de mim
         sign_in: Entrar
-      signed_in: 
-      signed_out: 
       user:
         signed_in: 
     shared:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root to: "home#index"
 
-  devise_for :users
+  devise_for :users, controllers: { sessions: "sessions" }
 
   devise_scope :user do
     get "login", to: "devise/sessions#new"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe SessionsController do
+  let(:user) do
+    Fabricate(:user, password: 'papapa22', password_confirmation: 'papapa22')
+  end
+
+  describe '#create' do
+    before do
+      request.env["devise.mapping"] = Devise.mappings[:user]
+    end
+
+    it 'does not show a notice flash message' do
+      post :create, user: {
+        email: user.email,
+        password: user.password
+      }
+      expect(flash[:notice]).to be_nil
+    end
+  end
+
+  describe '#destroy' do
+    before do
+      request.env["devise.mapping"] = Devise.mappings[:user]
+      post :create, user: {
+        email: user.email,
+        password: user.password
+      }
+    end
+
+    it 'does not show a notice flash message' do
+      delete :destroy
+      expect(flash[:notice]).to be_nil
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,10 @@ require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
 require 'capybara/rails'
+require 'database_cleaner'
+require 'fabrication'
+require 'faker'
+I18n.reload!
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Antes para quitar los avisos de login logout de devise lo hacíamos directamente con textos vacios en los yml de locales locales:"" pero localeapp no lo permite y hemos cambiado el método.