### PR TITLE
Decouple members and users resources

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -1,0 +1,12 @@
+class AccountController < ApplicationController
+  # GET /account
+  #
+  def show
+  end
+
+  # GET /account/edit
+  #
+  def edit
+    @user = current_user
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,7 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(user)
     if user.members.present?
-      users_path
+      members_path
     else
       page_path("about")
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,5 @@
 class HomeController < ApplicationController
   def index
-    redirect_to :users if current_user
+    redirect_to :members if current_user
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,20 +5,8 @@ class UsersController < ApplicationController
     current_organization.users
   end
 
-  def index
-    @users = scoped_users
-    @memberships = current_organization.members.
-                   where(user_id: @users.map(&:id)).
-                   includes(:account).each_with_object({}) do |mem, ob|
-                     ob[mem.user_id] = mem
-                   end
-  end
-
   def show
     @user = find_user
-    @member = @user.as_member_of(current_organization)
-    @movements = @member.movements.order("created_at DESC").page(params[:page]).
-                 per(10)
   end
 
   def new

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -7,7 +7,7 @@ module UsersHelper
       {
         id: user.id,
         avatar: avatar_url(user),
-        member_id: membership.member_uid,
+        member_uid: membership.member_uid,
         username: user.username,
         email: user.email_if_real,
         unconfirmed_email: user.unconfirmed_email,
@@ -15,7 +15,7 @@ module UsersHelper
         alt_phone: user.alt_phone,
         balance: membership.account_balance.to_i,
 
-        url: user_path(user),
+        url: member_path(membership.member_uid),
         edit_link: edit_user_path(user),
         cancel_link: cancel_member_path(membership),
         toggle_manager_link: toggle_manager_member_path(membership),

--- a/app/views/account/edit.html.erb
+++ b/app/views/account/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>
+  <%= @user.username %>
+  <small><%= t ".edit_user" %></small>
+</h1>
+
+<%= render "users/form" %>

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -1,0 +1,54 @@
+<div class="panel user-profile">
+  <div class="panel-body">
+    <h1>
+      <%= current_user.username %>
+      <small>
+        <% if current_user.superadmin? %>
+          <span class="label label-important">
+            <%= t ".superadmin" %>
+          </span>
+        <% end %>
+      </small>
+    </h1>
+    <div class="row">
+      <div class="col-sm-3 col-xs-5 text-center">
+        <a href="https://www.gravatar.com" target="_blank">
+          <%= image_tag avatar_url(current_user, 160) %>
+        </a>
+      </div>
+      <div class="col-sm-9 col-xs-7 break-word">
+        <%= m current_user.description %>
+        <ul class="nav nav-pills pull-right">
+          <li>
+            <%= link_to account_edit_path do %>
+              <%= glyph :pencil %>
+              <%= t "global.edit" %>
+            <% end %>
+          </li>
+        </ul>
+        <dl class="dl-horizontal">
+          <h3>
+            <%= t "global.contact_details" %>
+          </h3>
+          <% if current_user.email_if_real != "" %>
+            <dt>
+              <%= User.human_attribute_name(:email) %>
+            </dt>
+            <dd>
+              <%= current_user.email_if_real %>
+            </dd>
+          <% end %>
+          <% phones = [current_user.phone, current_user.alt_phone].select(&:present?) %>
+          <% if phones.present? %>
+            <dt>
+              <%= t(".phone", count: phones.size) %>
+            </dt>
+            <dd>
+              <%= phones.map(&:to_s).join('—') %>
+            </dd>
+          <% end %>
+        </dl>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -48,7 +48,7 @@
       <div class="row">
         <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
           <ul class="nav nav-pills actions-menu">
-              <%= render 'application/menus/user_list_link' %>
+              <%= render 'application/menus/members_list_link' %>
               <%= render 'application/menus/offers_dashboard_link' %>
               <%= render 'application/menus/inquiries_list_link' %>
               <%= render 'application/menus/offers_by_tag_link' %>

--- a/app/views/application/menus/_members_list_link.html.erb
+++ b/app/views/application/menus/_members_list_link.html.erb
@@ -1,0 +1,6 @@
+<li class="<%= "active" if current_page?(members_path) %>">
+  <%= link_to members_path do %>
+    <%= glyph :user %>
+    <%= Member.model_name.human.pluralize %>
+  <% end %>
+</li>

--- a/app/views/application/menus/_user_admin_menu.html.erb
+++ b/app/views/application/menus/_user_admin_menu.html.erb
@@ -25,7 +25,7 @@
       <li class="divider" role="presentation"></li>
     <% end %>
     <li role="presentation">
-      <%= link_to current_user do %>
+      <%= link_to account_path do %>
         <%= glyph :user %>
         <%= t "layouts.application.edit_profile" %>
       <% end %>

--- a/app/views/application/menus/_user_list_link.html.erb
+++ b/app/views/application/menus/_user_list_link.html.erb
@@ -1,6 +1,0 @@
-<li class="<%= "active" if current_page?(users_path) %>">
-  <%= link_to users_path do %>
-    <%= glyph :user %>
-    <%= User.model_name.human(count: :many) %>
-  <% end %>
-</li>

--- a/app/views/members/_members_rows.html.erb
+++ b/app/views/members/_members_rows.html.erb
@@ -3,7 +3,7 @@
   <td>
     <img ng-src="{{user.avatar}}" height: "32px" width: "32px">
   </td>
-  <td>{{user.member_id}}</td>
+  <td>{{user.member_uid}}</td>
   <td>
     <span class="glyphicon glyphicon-time" ng-if="!user.active"></span>
     <a ng-href="{{user.url}}">{{user.username}}</a>

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -1,6 +1,6 @@
 <div ng-controller="UserListCtrl">
   <h1>
-    <%= User.model_name.human.pluralize %>
+    <%= Member.model_name.human.pluralize %>
     —
     <%= link_to current_organization.name,
                 organization_path(current_organization) %>
@@ -23,7 +23,7 @@
         <li>
           <a href="<%= new_user_path %>">
             <span class="glyphicon glyphicon-plus"></span>
-            <%= t "helpers.submit.create", model: User.model_name.human %>
+            <%= t "helpers.submit.create", model: Member.model_name.human %>
           </a>
         </li>
       <% end %>
@@ -78,7 +78,7 @@
         </tr>
       </thead>
       <tbody>
-        <%= render "user_rows", users: @users %>
+        <%= render "members_rows", users: @users %>
       </tbody>
     </table>
   </div>

--- a/app/views/members/show.html.erb
+++ b/app/views/members/show.html.erb
@@ -1,0 +1,168 @@
+<div class="panel user-profile">
+  <div class="panel-body">
+    <h1>
+      <small>
+        <% unless @member.active %>
+          <%= t ".inactive" %>
+        <% end %>
+      </small>
+      <%= @member.display_name_with_uid %>
+      <small>
+        <% if @user.superadmin? %>
+          <span class="label label-important">
+            <%= t ".superadmin" %>
+          </span>
+        <% end %>
+      </small>
+    </h1>
+    <div class="row">
+      <div class="col-sm-3 col-xs-5 text-center">
+        <% if @user == current_user %>
+          <a href="https://www.gravatar.com" target="_blank">
+            <%= image_tag avatar_url(@user, 160) %>
+          </a>
+        <% else %>
+          <%= image_tag avatar_url(@user, 160) %>
+        <% end %>
+      </div>
+      <div class="col-sm-9 col-xs-7 break-word">
+        <%= m @user.description %>
+        <ul class="nav nav-pills pull-right">
+          <% if @user == current_user %>
+            <li>
+              <%= link_to account_edit_path do %>
+                <%= glyph :pencil %>
+                <%= t "global.edit" %>
+              <% end %>
+            </li>
+          <% end %>
+          <% if admin? || @user != current_user %>
+            <li>
+              <%= link_to give_time_user_path(@user) do %>
+                <%= glyph :time %>
+                <%= t "global.give_time" %>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+        <dl class="dl-horizontal">
+          <h3>
+            <%= t "global.contact_details" %>
+          </h3>
+          <% if @user.email_if_real != "" %>
+            <dt>
+              <%= User.human_attribute_name(:email) %>
+            </dt>
+            <dd>
+              <%= @user.email_if_real %>
+            </dd>
+          <% end %>
+          <% phones = [@user.phone, @user.alt_phone].select(&:present?) %>
+          <% if phones.present? %>
+            <dt>
+              <%= t(".phone", count: phones.size) %>
+            </dt>
+            <dd>
+              <%= phones.map(&:to_s).join('—') %>
+            </dd>
+          <% end %>
+        </dl>
+      </div>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-sm-6 offers">
+    <div class="panel panel-default break-word">
+      <div class="panel-heading">
+        <h2 class="panel-title">
+          <%= Offer.model_name.human(count: :many) %>
+          <% if @user == current_user %>
+            <a class="pull-right" href="<%= new_offer_path %>">
+              <%= glyph :plus %>
+            </a>
+          <% end %>
+        </h2>
+      </div>
+        <% @member.offers.active.each do |post| %>
+          <div class="row panel-body">
+            <div class="col-sm-3">
+              <%= link_to post, post %>
+            </div>
+            <div class="col-sm-8">
+              <%= strip_tags(post.rendered_description.to_html) %>
+            </div>
+            <div class="col-sm-1">
+              <% if @user != current_user %>
+                <%= link_to give_time_user_path(@user, offer: post.id) do %>
+                  <%= glyph :time %>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </table>
+    </div>
+  </div>
+  <div class="col-sm-6 inquiries">
+    <div class="panel panel-default break-word">
+      <div class="panel-heading">
+        <h2 class="panel-title">
+          <%= Inquiry.model_name.human(count: :many) %>
+          <% if @user == current_user %>
+            <a class="pull-right" href="<%= new_inquiry_path %>">
+              <%= glyph :plus %>
+            </a>
+          <% end %>
+        </h2>
+      </div>
+        <% @member.inquiries.active.each do |post| %>
+          <div class="row panel-body">
+            <div class="col-sm-3">
+              <%= link_to post, post %>
+            </div>
+            <div class="col-sm-9">
+              <%= strip_tags(post.rendered_description.to_html) %>
+            </div>
+          </div>
+        <% end %>
+      </table>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-sm-4">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+          <%= t(".accounts") %>
+        </h3>
+      </div>
+      <div class="panel-body">
+        <% if @member.manager %>
+          <p class="danger">
+            ADMIN
+          </p>
+        <% end %>
+        <p>
+          <strong>
+            <%= t(".created_at") %>
+          </strong>
+          <%= @member.entry_date ? l(@member.entry_date, format: :long) : mdash %>
+          <br/>
+          <strong>
+            <%= t(".user_no") %>
+          </strong>
+          <%= @member.member_uid || mdash %>
+          <br/>
+          <strong class="lead <%= green_red(@member.account&.balance) %>">
+            <%= t(".balance") %>
+            <%= seconds_to_hm(@member.account.try(:balance) || mdash) %>
+          </strong>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%= render 'shared/movements' %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,12 +1,7 @@
 <div class="panel user-profile">
   <div class="panel-body">
     <h1>
-      <small>
-        <% unless  @member.active %>
-          <%= t ".inactive" %>
-        <% end %>
-      </small>
-      <%= @member.display_name_with_uid %>
+      <%= @user.username %>
       <small>
         <% if @user.superadmin? %>
           <span class="label label-important">
@@ -30,7 +25,7 @@
         <ul class="nav nav-pills pull-right">
           <% if @user == current_user %>
             <li>
-              <%= link_to edit_user_path(@user) do %>
+              <%= link_to account_edit_path do %>
                 <%= glyph :pencil %>
                 <%= t "global.edit" %>
               <% end %>
@@ -71,98 +66,3 @@
     </div>
   </div>
 </div>
-<div class="row">
-  <div class="col-sm-6 offers">
-    <div class="panel panel-default break-word">
-      <div class="panel-heading">
-        <h2 class="panel-title">
-          <%= Offer.model_name.human(count: :many) %>
-          <% if @user == current_user %>
-            <a class="pull-right" href="<%= new_offer_path %>">
-              <%= glyph :plus %>
-            </a>
-          <% end %>
-        </h2>
-      </div>
-        <% @member.offers.active.each do |post| %>
-          <div class="row panel-body">
-            <div class="col-sm-3">
-              <%= link_to post, post %>
-            </div>
-            <div class="col-sm-8">
-              <%= strip_tags(post.rendered_description.to_html) %>
-            </div>
-            <div class="col-sm-1">
-              <% if @user != current_user %>
-                <%= link_to give_time_user_path(@user, offer: post.id) do %>
-                  <%= glyph :time %>
-                <% end %>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-      </table>
-    </div>
-  </div>
-  <div class="col-sm-6 inquiries">
-    <div class="panel panel-default break-word">
-      <div class="panel-heading">
-        <h2 class="panel-title">
-          <%= Inquiry.model_name.human(count: :many) %>
-          <% if @user == current_user %>
-            <a class="pull-right" href="<%= new_inquiry_path %>">
-              <%= glyph :plus %>
-            </a>
-          <% end %>
-        </h2>
-      </div>
-        <% @member.inquiries.active.each do |post| %>
-          <div class="row panel-body">
-            <div class="col-sm-3">
-              <%= link_to post, post %>
-            </div>
-            <div class="col-sm-9">
-              <%= strip_tags(post.rendered_description.to_html) %>
-            </div>
-          </div>
-        <% end %>
-      </table>
-    </div>
-  </div>
-</div>
-<div class="row">
-  <div class="col-sm-4">
-    <div class="panel panel-default">
-      <div class="panel-heading">
-        <h3 class="panel-title">
-          <%= t(".accounts") %>
-        </h3>
-      </div>
-      <div class="panel-body">
-        <% if @member.manager %>
-          <p class="danger">
-            ADMIN
-          </p>
-        <% end %>
-        <p>
-          <strong>
-            <%= t(".created_at") %>
-          </strong>
-          <%= @member.entry_date ? l(@member.entry_date, format: :long) : mdash %>
-          <br/>
-          <strong>
-            <%= t(".user_no") %>
-          </strong>
-          <%= @member.member_uid || mdash %>
-          <br/>
-          <strong class="lead <%= green_red(@member.account&.balance) %>">
-            <%= t(".balance") %>
-            <%= seconds_to_hm(@member.account.try(:balance) || mdash) %>
-          </strong>
-        </p>
-      </div>
-    </div>
-  </div>
-</div>
-
-<%= render 'shared/movements' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
 
   get "global/switch_lang", as: :switch_lang
 
+  get :account, controller: :account, action: :show
+  get 'account/edit', controller: :account, action: :edit
+
   resources :offers do
     collection do
       get :dashboard

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :users, concerns: :accountable, except: :destroy, :path => "members"
+  resources :users, concerns: :accountable, except: :destroy
 
   resources :transfers, only: [:create] do
     member do
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
 
   resources :documents
 
-  resources :members, only: [:destroy] do
+  resources :members, param: :member_uid, only: [:index, :show, :destroy] do
     member do
       put :toggle_manager
       put :toggle_active


### PR DESCRIPTION
Due to some design restriction decided when TO users could only pertain to one time bank, the `User` and `Member` resources were coupled and often used interchangeably. Now that we want to introduce the concept of "discover a time bank near to you" and multiple memberships we need to refactor and breack this coupling.

This PR is related to https://github.com/coopdevs/timeoverflow/pull/250, but independent. Although would be nice to merge this one first.