### PR TITLE
Search only active posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -31,6 +31,7 @@ class Post < ActiveRecord::Base
           indexes :description, analyzer: "normal"
           indexes :tags
           indexes :organization_id, type: :integer
+          indexes :active, type: :boolean
         end
       end
     end


### PR DESCRIPTION
I'm trying to solve https://github.com/coopdevs/timeoverflow/issues/262 but I found an issue for which I don't have an explanation yet.

As you see below, I had to add the `active` field in the ES index for posts. We want to find active posts only as we do with the DB query for `PostsController#index` normally.

Once I recreate the index I get:

```shell
$ curl localhost:9200/offers/_mappings?pretty=1
{
  "offers" : {
    "mappings" : {
      "offer" : {
        "properties" : {
          "active" : {
            "type" : "boolean"
          },
          "description" : {
            "type" : "string",
            "analyzer" : "normal"
          },
          "organization_id" : {
            "type" : "integer"
          },
          "tags" : {
            "type" : "string"
          },
          "title" : {
            "type" : "string",
            "analyzer" : "normal"
          }
        }
      }
    }
  }
}
```

Which is what I expect. However when I query all the documents in the index:

```shell
$ curl -X POST localhost:9200/offers/_search?pretty=1 -d '{"query": { "match_all": {} } } }' -H "Content-Type: application/json"
...
}, {
      "_index" : "offers",
      "_type" : "offer",
      "_id" : "6",
      "_score" : 1.0,
      "_source" : {
        "title" : "Pequeñas reparaciones de casa",
        "description" : "  Llamame y miramos que necesitas, si veo que puedo ayudarte nos ponemos a ello\n",
        "tags" : [ "casa", "manitas" ],
        "organization_id" : 1
      }
    }, {
...
```

`_source` contains all fields but `active` :thinking: As a result no query I tried specifying `active: true` worked.

The hypothesis I had was that perhaps `active` is a reserved word but in that case I'd expect seeing a failure on Elasticsearch's logs when import the records to it or when parsing the query. I can't seem to find a list of reserved words either...

@enricostano feel free to this PR over if you want while I'm off. This is all I could find.