### PR TITLE
Fix activeadmin's deprecation warning

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 ActiveAdmin.register User do
-  action_item only: :index do
+  action_item :upload_csv, only: :index do
     link_to I18n.t("active_admin.users.upload_from_csv"), action: "upload_csv"
   end
 


### PR DESCRIPTION
Provides a name to the action_item added to have the "Upload CSV"
button as specified by ActiveAdmin docs. (See https://activeadmin.info/8-custom-actions.html#action-items)

Before:

```
➜  timeoverflow (remove-activeadmin-warning) b rails s
warning: parser/current is loading parser/ruby22, which recognizes                                                                          warning: 2.2-compliant syntax, but you are running 2.3.0.                                                                                   
=> Booting Thin                                                                                                                             
=> Rails 4.2.5.2 application starting in development on http://localhost:3000                                                               
=> Run `rails server -h` for more startup options                                                                                           
=> Ctrl-C to shutdown server                                                                                                                
DEPRECATION WARNING: Active Admin: using `action_item` without a name is deprecated! Use `action_item(:edit)`. (called from action_item at /
home/pau/dev/timeoverflow/vendor/bundle/ruby/2.3.0/bundler/gems/activeadmin-60914c887942/lib/active_admin/dsl.rb:92)                        
Thin web server (v1.6.3 codename Protein Powder)                                                                         
Maximum connections set to 1024                                                                                                             
Listening on localhost:3000, CTRL+C to stop  
```

Now:

```
➜  timeoverflow (remove-activeadmin-warning) ADMINS=admin@timeoverflow.org b rails s                                                    ✭ ✱
warning: parser/current is loading parser/ruby22, which recognizes
warning: 2.2-compliant syntax, but you are running 2.3.0.                                                                                   => Booting Thin                                           
=> Rails 4.2.5.2 application starting in development on http://localhost:3000                                                               => Run `rails server -h` for more startup options                                                     
=> Ctrl-C to shutdown server                                                                                                                
Thin web server (v1.6.3 codename Protein Powder)                                                      
Maximum connections set to 1024                                                                                                             
Listening on localhost:3000, CTRL+C to stop          
```

The deprecation warning is gone and the button is still there:

![users](https://user-images.githubusercontent.com/762088/34933229-54e0a3f4-f9d6-11e7-8e52-43ba161f3aa8.png)
