### PR TITLE
Cleanup gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ ruby '2.3.0'
 
 gem 'rails', '4.2.5.2'
 gem 'rails-i18n'
-gem 'rails_12factor'
 gem "rdiscount"
 gem 'high_voltage', '~> 2.1.0'
 gem 'activeadmin', github: 'activeadmin'
@@ -74,4 +73,8 @@ group :test do
   gem 'shoulda', ">= 3.5"
   gem 'fabrication'
   gem 'faker'
+end
+
+group :production do
+  gem 'rails_12factor', '0.0.3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem "http_accept_language"
 gem 'thin'
 gem 'unicorn'
 gem 'foreman'
-gem 'dotenv-rails'
 gem 'kaminari'
 gem "simple_form", ">= 3.0.0"
 gem 'memcachier'
@@ -52,6 +51,7 @@ group :development do
   gem "quiet_assets"
   gem 'localeapp', '2.1.1', require: false
   gem 'letter_opener', '1.4.1'
+  gem 'dotenv-rails', '1.0.2'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem 'kaminari'
 gem "simple_form", ">= 3.0.0"
 gem 'memcachier'
 gem 'rollbar', '2.8.3'
-gem 'travis-lint'
 gem 'whenever', :require => false
 gem 'prawn'
 gem 'prawn-table'

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'foreman'
 gem 'dotenv-rails'
 gem 'kaminari'
 gem "simple_form", ">= 3.0.0"
-gem "awesome_print"
 gem 'memcachier'
 gem 'rollbar', '2.8.3'
 gem 'travis-lint'

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ group :development do
   gem 'web-console', '2.1.3'
   gem 'capistrano', '~> 3.1'
   gem 'capistrano-rails', '~> 1.1'
-  # gem 'capistrano3-delayed-job', '~> 1.0'
   gem 'airbrussh', require: false
   gem "quiet_assets"
   gem 'localeapp', '2.1.1', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,7 +411,7 @@ DEPENDENCIES
   quiet_assets
   rails (= 4.2.5.2)
   rails-i18n
-  rails_12factor
+  rails_12factor (= 0.0.3)
   rake
   rdiscount
   rollbar (= 2.8.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -383,7 +383,7 @@ DEPENDENCIES
   dalli
   database_cleaner (= 1.3.0)
   devise (= 3.5.6)
-  dotenv-rails
+  dotenv-rails (= 1.0.2)
   elasticsearch-model
   elasticsearch-rails
   fabrication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,8 +340,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
-    travis-lint (2.0.0)
-      json
     ttfunk (1.4.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -420,7 +418,6 @@ DEPENDENCIES
   shoulda (>= 3.5)
   simple_form (>= 3.0.0)
   thin
-  travis-lint
   uglifier (= 2.7.2)
   unicorn
   web-console (= 2.1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,6 @@ GEM
     autoprefixer-rails (6.3.1)
       execjs
       json
-    awesome_print (1.6.1)
     bcrypt (3.1.11)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -374,7 +373,6 @@ PLATFORMS
 DEPENDENCIES
   activeadmin!
   airbrussh
-  awesome_print
   better_errors
   binding_of_caller
   bootstrap-sass
@@ -429,4 +427,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.11.2
+   1.16.1


### PR DESCRIPTION
Our Gemfile has been very abandoned. Besides the fact that there are almost no versions specified, there are a number of dependencies that are either deprecated or in the wrong Gemfile group. This is just a small step towards a better Gemfile.

Basically, I remove deprecated or unnecessary ones and I moved to production those that should only be there. Read the commits and their explanations for more details. I also took the chance to fix couple versions, given that I was at it.