### PR TITLE
Fix translations not being picked up

### DIFF
--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -43,7 +43,7 @@
             <%= User.human_attribute_name(:alt_phone) %>
           </th>
           <th>
-            <%= sort_link @search, 'accounts_balance', User.human_attribute_name(:balance) %>
+            <%= sort_link @search, 'accounts_balance', Account.human_attribute_name(:balance) %>
           </th>
           <% if current_user.manages? current_organization %>
             <th>


### PR DESCRIPTION
This attribute belongs to another model, so Rails couldn't find its translation. Now the users `:index` shows `balance` properly translated in each locale.