### PR TITLE
Show data for membership in current organization

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,12 @@ class UsersController < ApplicationController
       .eager_load(members: :account)
       .page(params[:page])
       .per(25)
+
+    @memberships = current_organization.members.
+      where(user_id: @users.map(&:id)).
+      includes(:account).each_with_object({}) do |mem, ob|
+        ob[mem.user_id] = mem
+      end
   end
 
   def show

--- a/app/views/users/_user_rows.html.erb
+++ b/app/views/users/_user_rows.html.erb
@@ -1,5 +1,5 @@
 <% users.each do |user| %>
-  <% membership = user.members.first %>
+  <% membership = memberships[user.id] %>
 
   <%= content_tag(:tr, class: membership.active? ? "" : "bg-danger") do %>
     <td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -54,7 +54,7 @@
         </tr>
       </thead>
       <tbody>
-        <%= render "user_rows", users: @users %>
+        <%= render "user_rows", users: @users, memberships: @memberships %>
       </tbody>
     </table>
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,28 +1,28 @@
 require "spec_helper"
 
 describe UsersController do
-  let (:test_organization) { Fabricate(:organization) }
-  let (:member_admin) do
+  let(:test_organization) { Fabricate(:organization) }
+  let(:member_admin) do
     Fabricate(:member,
               organization: test_organization,
               manager: true)
   end
-  let (:member) do
+  let(:member) do
     Fabricate(:member,
               organization: test_organization,
               manager: false)
   end
-  let (:another_member) do
+  let(:another_member) do
     Fabricate(:member,
               organization: test_organization,
               manager: false)
   end
-  let (:wrong_email_member) do
+  let(:wrong_email_member) do
     Fabricate(:member,
               organization: test_organization,
               manager: false)
   end
-  let (:empty_email_member) do
+  let(:empty_email_member) do
     Fabricate(:member,
               organization: test_organization,
               manager: false)
@@ -38,6 +38,35 @@ describe UsersController do
   before { set_browser_locale("ca") }
 
   describe "GET #index" do
+    context 'when a user has many memberships' do
+      let!(:member_in_another_organization) { Fabricate(:member, user: user) }
+
+      before do
+        login(user)
+        member.account.update_attribute(
+          :balance,
+          Time.parse('13:33').seconds_since_midnight
+        )
+      end
+
+      it 'gets her membership in the current organization' do
+        get :index
+
+        expect(assigns(:memberships)).to eq({
+          member.user_id => member,
+          another_member.user_id => another_member,
+          member_admin.user_id => member_admin,
+          wrong_email_member.user_id => wrong_email_member,
+          empty_email_member.user_id => empty_email_member
+        })
+      end
+
+      it 'shows data for her membership in the current organization' do
+        get :index
+        expect(response.body).to include("<td> 13:33 </td>")
+      end
+    end
+
     context "with an normal logged user" do
       it "populates and array of users" do
         login(user)


### PR DESCRIPTION
Now, we show the first membership of the user regardless of the organization it belongs to.

We weren't fetching the memberships in the current organization, for the users presents in the list. As a result, we were displaying the first user's membership data.