### PR TITLE
Fix sort users by their member_uid

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
 
   def index
     @search = current_organization.users.ransack(params[:q])
+    @search.sorts = 'members_member_uid asc' if @search.sorts.empty?
 
     @users = @search
       .result(distinct: false)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -38,11 +38,26 @@ describe UsersController do
   before { set_browser_locale("ca") }
 
   describe "GET #index" do
+    before { login(user) }
+
+    it 'sorts the users by their member_uid' do
+      member.update_attribute(:member_uid, 100)
+
+      get :index
+
+      expect(assigns(:users)).to eq([
+        another_user,
+        admin_user,
+        wrong_user,
+        empty_email_user,
+        user,
+      ])
+    end
+
     context 'when a user has many memberships' do
       let!(:member_in_another_organization) { Fabricate(:member, user: user) }
 
       before do
-        login(user)
         member.account.update_attribute(
           :balance,
           Time.parse('13:33').seconds_since_midnight


### PR DESCRIPTION
This was done with angular on the client side so far. Now fetching the users list was moved to the backend and so has to be the sorting.