### PR TITLE
Fix/pay from offer

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -18,4 +18,13 @@ class OffersController < PostsController
       offers[category] = list if list.present?
     end
   end
+
+  def show
+    super
+    @destination_account = @offer
+      .user
+      .members
+      .find_by(organization: current_organization)
+      .account
+  end
 end

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -21,10 +21,8 @@ class OffersController < PostsController
 
   def show
     super
-    @destination_account = @offer
-      .user
-      .members
-      .find_by(organization: current_organization)
-      .account
+
+    member = @offer.user.members.find_by(organization: current_organization)
+    @destination_account = member.account if member
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -43,7 +43,6 @@ class Post < ActiveRecord::Base
   belongs_to :user
   belongs_to :organization
   belongs_to :publisher, class_name: "User", foreign_key: "publisher_id"
-  # belongs_to :member, class_name: "Member", foreign_key: "user_id"
   has_many :user_members, class_name: "Member", through: :user, source: :members
   has_many :transfers
   has_many :movements, through: :transfers

--- a/app/views/offers/show.html.erb
+++ b/app/views/offers/show.html.erb
@@ -12,7 +12,7 @@
     <% end %>
   <% end %>
   <% if current_user and @offer.user != current_user %>
-    <%= link_to new_transfer_path(id: @offer.user.id, offer: @offer.id),
+    <%= link_to new_transfer_path(id: @offer.user.id, offer: @offer.id, destination_account_id: @destination_account.id),
                 class: "btn btn-success" do %>
       <%= glyph :time %>
       <%= t ".give_time_for" %>

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -62,16 +62,14 @@ describe OffersController, type: :controller do
   describe "GET #show" do
     context "with valid params" do
       context "with a logged user" do
-        it "assigns the requested offer to @offer" do
-          login(another_member.user)
+        before { login(another_member.user) }
 
-          get "show", id: offer.id
+        it "assigns the requested offer to @offer" do
+          get :show, id: offer.id
           expect(assigns(:offer)).to eq(offer)
         end
 
         it 'assigns the account destination of the transfer' do
-          login(another_member.user)
-
           get :show, id: offer.id
           expect(assigns(:destination_account)).to eq(member.account)
         end
@@ -79,7 +77,7 @@ describe OffersController, type: :controller do
 
       context "without a logged in user" do
         it "assigns the requested offer to @offer" do
-          get "show", id: offer.id
+          get :show, id: offer.id
           expect(assigns(:offer)).to eq(offer)
         end
       end

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -1,18 +1,20 @@
 require "spec_helper"
 
 describe OffersController, type: :controller do
-  let (:test_organization) { Fabricate(:organization) }
-  let (:member) { Fabricate(:member, organization: test_organization) }
-  let (:another_member) { Fabricate(:member, organization: test_organization) }
-  let (:yet_another_member) { Fabricate(:member) }
-  let (:test_category) { Fabricate(:category) }
-  let! (:offer) do
+  let(:test_organization) { Fabricate(:organization) }
+  let(:member) { Fabricate(:member, organization: test_organization) }
+  let(:another_member) { Fabricate(:member, organization: test_organization) }
+  let(:yet_another_member) { Fabricate(:member) }
+  let(:test_category) { Fabricate(:category) }
+  let!(:offer) do
     Fabricate(:offer,
               user: member.user,
               organization: test_organization,
               category: test_category)
   end
+
   include_context "stub browser locale"
+
   before { set_browser_locale("ca") }
 
   describe "GET #index" do
@@ -66,7 +68,15 @@ describe OffersController, type: :controller do
           get "show", id: offer.id
           expect(assigns(:offer)).to eq(offer)
         end
+
+        it 'assigns the account destination of the transfer' do
+          login(another_member.user)
+
+          get :show, id: offer.id
+          expect(assigns(:destination_account)).to eq(member.account)
+        end
       end
+
       context "without a logged in user" do
         it "assigns the requested offer to @offer" do
           get "show", id: offer.id

--- a/spec/fabricators/account_fabricator.rb
+++ b/spec/fabricators/account_fabricator.rb
@@ -1,0 +1,2 @@
+Fabricator(:account) do
+end

--- a/spec/views/offers/show.html.erb_spec.rb
+++ b/spec/views/offers/show.html.erb_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'offers/show' do
+  let(:organization) { Fabricate(:organization) }
+  let(:logged_user) { Fabricate(:user) }
+  let(:member) { Fabricate(:member, organization: organization) }
+  let(:offer) { Fabricate(:offer, user: member.user) }
+  let(:destination_account) { Fabricate(:account) }
+
+  before do
+    Fabricate(
+      :member,
+      organization: organization,
+      user: logged_user
+    )
+
+    allow(view).to receive(:admin?).and_return(false)
+    allow(view).to receive(:current_user).and_return(logged_user)
+    allow(view).to receive(:current_organization) { organization }
+
+    allow(offer).to receive(:member).and_return(member)
+  end
+
+  it 'renders a link to the transfer page' do
+    assign :offer, offer
+    assign :destination_account, destination_account
+    render template: 'offers/show'
+
+    expect(rendered).to have_link(
+        t('offers.show.give_time_for'),
+        href: new_transfer_path(
+          id: offer.user.id,
+          offer: offer.id,
+          destination_account_id: destination_account.id
+        )
+    )
+  end
+end

--- a/spec/views/offers/show.html.erb_spec.rb
+++ b/spec/views/offers/show.html.erb_spec.rb
@@ -2,37 +2,74 @@ require 'spec_helper'
 
 describe 'offers/show' do
   let(:organization) { Fabricate(:organization) }
-  let(:logged_user) { Fabricate(:user) }
   let(:member) { Fabricate(:member, organization: organization) }
-  let(:offer) { Fabricate(:offer, user: member.user) }
+  let(:offer) { Fabricate(:offer, user: member.user, organization: organization) }
   let(:destination_account) { Fabricate(:account) }
 
   before do
-    Fabricate(
-      :member,
-      organization: organization,
-      user: logged_user
-    )
-
     allow(view).to receive(:admin?).and_return(false)
-    allow(view).to receive(:current_user).and_return(logged_user)
     allow(view).to receive(:current_organization) { organization }
 
     allow(offer).to receive(:member).and_return(member)
   end
 
-  it 'renders a link to the transfer page' do
-    assign :offer, offer
-    assign :destination_account, destination_account
-    render template: 'offers/show'
+  context 'when there is logged in' do
+    let(:logged_user) { Fabricate(:user) }
 
-    expect(rendered).to have_link(
+    before do
+      Fabricate(
+        :member,
+        organization: organization,
+        user: logged_user
+      )
+
+      allow(view).to receive(:current_user).and_return(logged_user)
+    end
+
+    it 'renders a link to the transfer page' do
+      assign :offer, offer
+      assign :destination_account, destination_account
+      render template: 'offers/show'
+
+      expect(rendered).to have_link(
         t('offers.show.give_time_for'),
         href: new_transfer_path(
           id: offer.user.id,
           offer: offer.id,
           destination_account_id: destination_account.id
         )
-    )
+      )
+    end
+  end
+
+  context 'where is a guest user' do
+    before do
+      allow(view).to receive(:current_user).and_return(nil)
+    end
+
+    it 'does not render a link to the transfer page' do
+      assign :offer, offer
+      assign :destination_account, destination_account
+      render template: 'offers/show'
+
+      expect(rendered).not_to have_link(
+        t('offers.show.give_time_for'),
+        href: new_transfer_path(
+          id: offer.user.id,
+          offer: offer.id,
+          destination_account_id: destination_account.id
+        )
+      )
+    end
+
+    it 'renders a link to the login page' do
+      assign :offer, offer
+      render template: 'offers/show'
+
+      expect(rendered).to have_link(
+        t('layouts.application.login'),
+        href: new_user_session_path
+      )
+    end
   end
 end


### PR DESCRIPTION
## What? Why?

Closes #315.

I forgot to provide the destination of the account in the link to transfer, showed on the offer page. This was fetched in `UsersController#give_time` and later passed to the `give_time` view.

When I did the refactor I forgot to move that from https://github.com/coopdevs/timeoverflow/pull/264/files#diff-4e05ad0d64e6100656b63ad1e78f32c5L67 to the appropriate place (the `OffersController#show`), so that we specify the destination in the `link_to`.

## Introducing view specs :tada: 

Since this had to do also with the view, I thought it was the perfect timing to start doing view specs. I've wanted to add them soon to replace the pseudo pattern matching that we ended up doing in some controller specs to ensure stuff in the views.

I figured it'd be faster to get the test I wanted for the view in this way rather than using the current approach in the controller spec. And I was right. Having the capybara RSpec matchers available, such as `have_link` help a lot. You spend less time checking how does the actual returned HTML look like.
