### PR TITLE
Add Skylight instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'prawn-table'
 gem 'bundler', '>= 1.10.6'
 gem 'elasticsearch-model'
 gem 'elasticsearch-rails'
+gem 'skylight'
 
 # Assets
 gem 'jquery-rails', '4.0.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -330,6 +330,8 @@ GEM
     simple_form (3.1.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
+    skylight (1.5.0)
+      activesupport (>= 3.0.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -425,6 +427,7 @@ DEPENDENCIES
   select2-rails
   shoulda (>= 3.5)
   simple_form (>= 3.0.0)
+  skylight
   thin
   uglifier (= 2.7.2)
   unicorn


### PR DESCRIPTION
I discussed with @coopdevs about adding Skylight instrumentation to the TimeOverflow website under the new [Skylight for Open Source](https://www.skylight.io/oss) program.

If you’re not already familiar with Skylight, it is a smart profiler for Rails apps. Skylight makes it easy to pinpoint performance issues in Rails applications.

We work on a lot of open source projects ourselves, and in our experience it can be pretty hard to get contributors to work on application performance issues. Few contributors consider working on performance problems, and the ones that might be interested may not even know where to start. By making performance information more accessible, we hope to inspire potential contributors to tackle slow parts of your app, and have a good way to see if their contributions helped.

Once this patch is merged and deloyed*, you will be able to view the performance data we collected at the [public Skylight dashboard](https://oss.skylight.io/app/applications/grDTNuzZRnyu). The dashboard will be accessible to anyone (no Skylight account required) to make it easy for contributors.

(*Actually, I lied a little. We still need to set the `SKYLIGHT_AUTHENTICATION` environment variable to the appropiate API key on production, but I will work with @coopdevs on that off-thread.)