### PR TITLE
Require capistrano-rbenv only in staging

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -16,7 +16,11 @@ require 'capistrano/deploy'
 #   https://github.com/capistrano/passenger
 #
 require 'capistrano/rails'
-require 'capistrano/rbenv'
+
+stage = ARGV.first
+if stage == :staging # Sorry, production is not ready yet
+  require 'capistrano/rbenv'
+end
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }


### PR DESCRIPTION
Production is not provisioned with Rbenv yet. We're first refactoring staging's provisioning and then, we'll work on production. So, this patch is temporary.

This fixes the issue we had in https://github.com/coopdevs/timeoverflow/releases/tag/v1.3.0 while
deploying and https://github.com/coopdevs/timeoverflow/releases/tag/v1.3.1 fixed.

Then we can bring these changes related to `capistrano-rbenv` back to `master`.