### PR TITLE
Mobile styles using bootstrap screen size variables

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -2,6 +2,9 @@
  *= require_self
  */
 
+@import "bootstrap-sprockets";
+@import "bootstrap";
+
 $bg-color: #f5f8fa;
 $navs-bg-color: #1e1e1e;
 $white: #ffffff;

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -92,6 +92,10 @@ html {
 
   span.input-group-addon {
     padding: 2rem 2rem 2rem 3rem;
+
+    @media (max-width: $screen-xs-min) {
+      display: none;
+    }
   }
 
   span.show-password {
@@ -307,7 +311,6 @@ table.users {
       max-width: 100%;
     }
   }
-
 }
 
 @media print {
@@ -628,6 +631,10 @@ form .checkbox input[type="checkbox"] {
     letter-spacing: 0.031rem;
     margin-bottom: 2rem;
     margin-top: 3rem;
+
+    @media (max-width: $screen-xs-min) {
+      display: none;
+    }
   }
 
   .material-icons {

--- a/app/assets/stylesheets/libs.scss
+++ b/app/assets/stylesheets/libs.scss
@@ -2,6 +2,3 @@
 *= require jquery-ui
 *= require select2
 */
-
-@import "bootstrap-sprockets";
-@import "bootstrap";


### PR DESCRIPTION
Just a PoC of how to use the bootstrap screen size variables to create the media queries.

As an example, I simplified the login box in mobile devices:

<img width="622" alt="screen shot 2018-03-14 at 15 32 29" src="https://user-images.githubusercontent.com/935744/37412502-f275dbf4-279c-11e8-9793-b12a46701cec.png">
