### PR TITLE
add link to gravatar

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -21,6 +21,9 @@
           <a href="https://www.gravatar.com" target="_blank">
             <%= image_tag avatar_url(@user, 160) %>
           </a>
+          <a href="https://www.gravatar.com" target="_blank" class="btn btn-link">
+            <%= glyph :pencil %> <%= t ".change_your_image" %>
+          </a>
         <% else %>
           <%= image_tag avatar_url(@user, 160) %>
         <% end %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -518,6 +518,7 @@ ca:
       accounts: Comptes
       balance: 'Balanç:'
       categories: Serveis Ofertats
+      change_your_image: Canvia la teva imatge
       created_at: 'Alta:'
       data: Dades de l'usuari
       date: Data

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -518,6 +518,7 @@ en:
       accounts: Accounts
       balance: 'Balance:'
       categories: Offered Services
+      change_your_image: Change your image
       created_at: 'Registered:'
       data: User details
       date: Date

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -518,6 +518,7 @@ es:
       accounts: Cuentas
       balance: 'Balance:'
       categories: Servicios Ofrecidos
+      change_your_image: Cambia tu imagen
       created_at: 'Alta:'
       data: Datos del usuario
       date: Fecha

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -524,6 +524,7 @@ eu:
       accounts: Kontuak
       balance: 'Balantzea:'
       categories: Eskainiriko zerbitzuak
+      change_your_image:
       created_at: 'Alta:'
       data: Erabiltzailearen datuak
       date: Eguna

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -518,6 +518,7 @@ pt-BR:
       accounts: Contas
       balance: 'Balanço:'
       categories: Serviços Oferecidos
+      change_your_image:
       created_at: 'Inscrição:'
       data: Dados do usuário
       date: Data


### PR DESCRIPTION
Closes #274

> We want (before big change in avatar system) to put a link below avatar image to https://www.gravatar.com/

**I18n**
 
New key: `users.show.change_your_image`

![captura de pantalla 2018-03-18 a la s 20 09 25](https://user-images.githubusercontent.com/576701/37569857-7921638c-2ae8-11e8-97be-19476dd7d5f3.png)

