### PR TITLE
Upgrade loofah to fix security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
       i18n (~> 0.4)
       json
       rest-client
-    loofah (2.2.0)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -245,8 +245,8 @@ GEM
       activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     rails-i18n (4.0.3)
       i18n (~> 0.6)
       railties (~> 4.0)


### PR DESCRIPTION
This fixes the security vulnerability on Loofah 2.2.0 Github reported.
See https://github.com/flavorjones/loofah/issues/144 for details.

A `bundle update --conservative rails-html-sanitizer` did the trick.