### PR TITLE
Expose Ruby version via Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby File.read('.ruby-version').strip
+
 gem 'rails', '~> 4.2'
 gem 'rails-i18n'
 gem "rdiscount"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,5 +414,8 @@ DEPENDENCIES
   web-console (= 2.1.3)
   whenever
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
Closes #340 

This reverts changes made in bf6853dd2c2aaa98146e2b07953559eaf6165fed, but sets the version by reading the Ruby version already defined in the `.ruby-version` file.