### PR TITLE
fix statistics_inactive_users html

### DIFF
--- a/app/views/statistics/statistics_inactive_users.html.erb
+++ b/app/views/statistics/statistics_inactive_users.html.erb
@@ -12,19 +12,19 @@
           <th><%= t '.last_movement' %></th>
         </tr>
       </thead>
-      <tbody></tbody>
-      <%# Por días sin movimientos %>
-      <% @members.includes(:account)
-                 .sort_by(&:days_without_swaps)
-                 .reverse
-                 .each do |mem| %>
-        <tr>
-          <td><%= mem.member_uid %></td>
-          <td><%= link_to mem.user.username, mem.user %></td>
-          <td><%= mem.days_without_swaps %></td>
-          <td><%= (mem.account.updated_at == mem.account.created_at) ? t(".no_movements") : l(mem.account.updated_at, format: :long) %></td>
-        </tr>
-      <% end %>
+      <tbody>
+        <% @members.includes(:account)
+                   .sort_by(&:days_without_swaps)
+                   .reverse
+                   .each do |mem| %>
+          <tr>
+            <td><%= mem.member_uid %></td>
+            <td><%= link_to mem.user.username, mem.user %></td>
+            <td><%= mem.days_without_swaps %></td>
+            <td><%= (mem.account.updated_at == mem.account.created_at) ? t(".no_movements") : l(mem.account.updated_at, format: :long) %></td>
+          </tr>
+        <% end %>
+      </tbody>
     </table>
   </div>
 </div>


### PR DESCRIPTION
Little 🐛 in `statistics_inactive_users` view (Latest Firefox).

Fix: render `tr` inside `tbody`.

Before (note the weird effect: borders appear on hover and not on initial render):
![stats1](https://user-images.githubusercontent.com/576701/40629732-91d1b98c-62cd-11e8-8fe5-67f0794bf48a.gif)

After:
![stats2](https://user-images.githubusercontent.com/576701/40629735-964928ec-62cd-11e8-8edd-e53320e7f67b.gif)

