### PR TITLE
Add sidekiq-cron

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,10 @@ gem 'elasticsearch-model'
 gem 'elasticsearch-rails'
 gem 'skylight'
 gem 'sidekiq', '5.1.3'
+gem 'sidekiq-cron', '0.6.3'
+# TODO: remove this once the following issue has been addressed
+#       https://github.com/ondrejbartas/sidekiq-cron/issues/199
+gem 'rufus-scheduler', '~> 3.4.2'
 
 # Assets
 gem 'jquery-rails', '>= 4.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,8 @@ GEM
       multi_json
     erubi (1.7.1)
     erubis (2.7.0)
+    et-orbi (1.1.2)
+      tzinfo
     execjs (2.6.0)
     fabrication (2.11.3)
     faker (1.4.3)
@@ -321,6 +323,8 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     rubyzip (1.2.1)
+    rufus-scheduler (3.4.2)
+      et-orbi (~> 1.0)
     sass (3.4.21)
     sass-rails (5.0.7)
       railties (>= 4.0.0, < 6)
@@ -340,6 +344,9 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    sidekiq-cron (0.6.3)
+      rufus-scheduler (>= 3.3.0)
+      sidekiq (>= 4.2.1)
     simple_form (3.1.0)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
@@ -430,10 +437,12 @@ DEPENDENCIES
   rollbar (= 2.8.3)
   rspec-rails (~> 3.7.2)
   rubocop (~> 0.52.1)
+  rufus-scheduler (~> 3.4.2)
   sass-rails (~> 5.0.7)
   select2-rails
   shoulda-matchers (~> 3.1.2)
   sidekiq (= 5.1.3)
+  sidekiq-cron (= 0.6.3)
   simple_form (>= 3.0.0)
   skylight
   uglifier (= 2.7.2)
@@ -445,4 +454,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,5 @@
+schedule_file = 'config/schedule.yml'
+
+if File.exist?(schedule_file) && Sidekiq.server?
+  Sidekiq::Cron::Job.load_from_hash YAML.load_file(schedule_file)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 require 'sidekiq/web'
+require 'sidekiq/cron/web'
 
 Rails.application.routes.draw do
   root to: "home#index"

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:queues:
+  - default
+  - cron


### PR DESCRIPTION
We need to execute cron jobs and since we're using Sidekiq for background jobs we'll use https://github.com/ondrejbartas/sidekiq-cron

We also add a new queue to the `default` one, called `cron`.