### PR TITLE
Add Skylight's performance data badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TimeOverflow [![Build Status](https://travis-ci.org/coopdevs/timeoverflow.svg)](https://travis-ci.org/coopdevs/timeoverflow) [![Code Climate](https://codeclimate.com/github/timeoverflow/timeoverflow/badges/gpa.svg)](https://codeclimate.com/github/timeoverflow/timeoverflow)
+# TimeOverflow [![View performance data on Skylight](https://badges.skylight.io/problem/grDTNuzZRnyu.svg)](https://oss.skylight.io/app/applications/grDTNuzZRnyu) [![Build Status](https://travis-ci.org/coopdevs/timeoverflow.svg)](https://travis-ci.org/coopdevs/timeoverflow) [![Code Climate](https://codeclimate.com/github/timeoverflow/timeoverflow/badges/gpa.svg)](https://codeclimate.com/github/timeoverflow/timeoverflow)
 #### www.timeoverflow.org
 
 :globe_with_meridians: Read this [in English](docs/README.en.md)


### PR DESCRIPTION
This not only shows response time of TO's problematic responses but it is also a requirement for Skylight to display TO in their showcase page.

You can checkout Skylight [here](https://oss.skylight.io/app/applications/grDTNuzZRnyu/1527907140/1d/endpoints)