### PR TITLE
Fix regression switching between organizations

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -41,6 +41,8 @@ class OrganizationsController < ApplicationController
     redirect_to organizations_path, notice: "deleted"
   end
 
+  # POST /organizations/:organization_id/set_current
+  #
   def set_current
     if current_user
       session[:current_organization_id] = @organization.id

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,5 +1,5 @@
 class OrganizationsController < ApplicationController
-  before_filter :load_resource, only: [:show, :edit, :update, :destroy]
+  before_filter :load_resource, only: [:show, :edit, :update, :destroy, :set_current]
 
   def new
     @organization = Organization.new

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -1,14 +1,26 @@
 require 'spec_helper'
 
-describe OrganizationsController do
-  describe '#show' do
-    let(:organization) { Fabricate(:organization) }
+RSpec.describe OrganizationsController do
+  let(:organization) { Fabricate(:organization) }
+  let(:member) { Fabricate(:member, organization: organization) }
+  let(:user) { member.user }
 
+  describe '#show' do
     it 'links to new_transfer_path' do
       get 'show', id: organization.id
       expect(response.body).to include(
         "<a href=\"/transfers/new?destination_account_id=#{organization.account.id}&amp;id=#{organization.id}\">"
       )
+    end
+  end
+
+  describe '#set_current' do
+    before { login(user) }
+
+    it 'stores the given organization as current organization in session' do
+      post 'set_current', id: organization.id
+
+      expect(session[:current_organization_id]).to eq(organization.id)
     end
   end
 end


### PR DESCRIPTION
## WAT
Closes #383, adding `set_current` action to `load_resource` before filter whitelist.

## How to test
1. log in with `admin2@timeoverflow.org`, the user that pertains to 2 time banks
2. click on the name of the other time bank and check that it actually switches to it