### PR TITLE
Fix login panel vertical positioning issue

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -45,6 +45,7 @@ html {
 
 #login-box {
   border-radius: 0.3rem;
+  margin-bottom: 40px;
 
   form {
     border: 0;
@@ -386,10 +387,10 @@ label[required]::after{
   }
 
   .vertical-align {
-    position: absolute;
-    top: 46%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    height: auto;
+    position: static;
+    top: 0;
+    transform: none;
     width: 100%;
   }
 


### PR DESCRIPTION
Closes #278.

A few CSS tweaks so the vertical positioning of the login modal doesn't jump around when it's inner content changes in height.