### PR TITLE
Fix high severity vulnerability in Sprockets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ GEM
       skylight-core (= 2.0.1)
     skylight-core (2.0.1)
       activesupport (>= 4.2.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
This fixes CVE-2018-3760. According to https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k, the release 3.7.2 fixes it.

I got the report from Github.

![screenshot from 2018-06-22 13-43-55](https://user-images.githubusercontent.com/762088/41775037-6d9e92b6-7622-11e8-80df-6b89643bbf0b.png)
