### PR TITLE
Fixed login vertical alignment

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -405,13 +405,14 @@ label[required]::after{
 
   .login-wrapper {
     position: absolute;
-    top: 20%;
+    top: 51%;
     left: 0;
+    transform: translateY(-50%);
     width: 100%;
     z-index: 1;
 
     @media(max-width: $screen-sm-min) {
-      top: 60px;
+      top: 47%;
     }
   }
 


### PR DESCRIPTION
Should fix https://github.com/coopdevs/timeoverflow/issues/278

Improved the way we position the login box. Now it is vertically centered, so it plays better in screens that are not very high. 

![](http://g.recordit.co/rfv6n3arfF.gif)

http://g.recordit.co/rfv6n3arfF.gif

