### PR TITLE
Re-implement the member_uid searcher

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -60,7 +60,14 @@ class UsersController < ApplicationController
   private
 
   def search_params
-    {s: 'member_uid asc'}.merge(params.fetch(:q, {}))
+    q = params.fetch(:q, {})
+
+    if params[:q].present?
+      q[:member_uid_eq] = q[:user_username_or_user_email_contains]
+      q[:m] = 'or'
+    end
+
+    { s: 'member_uid asc' }.merge(q)
   end
 
   def scoped_users

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,9 +1,4 @@
 class Member < ActiveRecord::Base
-  # Cast the member_uid integer to a string to allow pg ILIKE search (from Ransack *_contains)
-  ransacker :member_uid do
-    Arel.sql("to_char(member_uid, '9999999')")
-  end
-
   belongs_to :user
   belongs_to :organization
   has_one :account, as: :accountable

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,7 +11,7 @@
     <div class="col-md-12">
       <%= search_form_for(@search, class: "navbar-form navbar-left", url: users_path) do |f| %>
         <div class="form-group">
-          <%= f.search_field :user_username_or_user_email_or_member_uid_contains, class: "form-control" %>
+          <%= f.search_field :user_username_or_user_email_contains, class: "form-control" %>
         </div>
         <button class="btn btn-default" type="submit">
           <%= t 'global.search' %>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -133,7 +133,7 @@ describe UsersController do
         user = Fabricate(:user, username: 'foo', email: 'foo@email.com')
         member = Fabricate(:member, user: user, organization: test_organization, member_uid: 1000)
 
-        get :index, q: { user_username_or_user_email_or_member_uid_contains: 1000 }
+        get :index, q: { user_username_or_user_email_contains: 1000 }
 
         expect(assigns(:members)).to include(member)
       end


### PR DESCRIPTION
Re-implement the member_uid searcher by avoiding the column casting thing (gives some problems when sorting the "casted" column as an string). The new strategy: combine both fields in the controller by manupilating the query parameters sent to Ransack.

Closes #398 
Closes #400