### PR TITLE
Re-implement the member_uid searcher (different approach)

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,7 +1,7 @@
 class Member < ActiveRecord::Base
   # Cast the member_uid integer to a string to allow pg ILIKE search (from Ransack *_contains)
-  ransacker :member_uid do
-    Arel.sql("to_char(member_uid, '9999999')")
+  ransacker :member_uid_search do
+    Arel.sql("member_uid::text")
   end
 
   belongs_to :user

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -11,7 +11,7 @@
     <div class="col-md-12">
       <%= search_form_for(@search, class: "navbar-form navbar-left", url: users_path) do |f| %>
         <div class="form-group">
-          <%= f.search_field :user_username_or_user_email_or_member_uid_contains, class: "form-control" %>
+          <%= f.search_field :user_username_or_user_email_or_member_uid_search_contains, class: "form-control" %>
         </div>
         <button class="btn btn-default" type="submit">
           <%= t 'global.search' %>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -133,7 +133,7 @@ describe UsersController do
         user = Fabricate(:user, username: 'foo', email: 'foo@email.com')
         member = Fabricate(:member, user: user, organization: test_organization, member_uid: 1000)
 
-        get :index, q: { user_username_or_user_email_or_member_uid_contains: 1000 }
+        get :index, q: { user_username_or_user_email_or_member_uid_search_contains: 1000 }
 
         expect(assigns(:members)).to include(member)
       end


### PR DESCRIPTION
New strategy: rename the ransacker so the cast only happens when filtering.

Thanks to @mllocs for the proposal: https://github.com/coopdevs/timeoverflow/pull/399#issuecomment-413219341

Closes #398 
Closes #399