### PR TITLE
Add conditions to PushNotification creation for Post

### DIFF
--- a/app/services/push_notifications/event_notifier/post.rb
+++ b/app/services/push_notifications/event_notifier/post.rb
@@ -14,13 +14,28 @@ module PushNotifications
       #
       # @return [<DeviceToken>]
       def device_tokens
-        organization = post.organization
-        DeviceToken.where(user_id: organization.user_ids)
+        DeviceToken.where(user_id: user_ids)
       end
 
       private
 
       attr_accessor :event, :post
+
+      # Returns an ActiveRecord relation with the ids of the users
+      # that comply the following conditions:
+      #
+      # - they have an active membership
+      # - their `push_notification` flag is set to true
+      #
+      # @return <User::ActiveRecord_AssociationRelation>
+      def user_ids
+        post
+          .organization
+          .users
+          .select(:id)
+          .where('members.active = true')
+          .where('users.push_notifications = true')
+      end
     end
   end
 end

--- a/spec/services/push_notifications/event_notifier/post_spec.rb
+++ b/spec/services/push_notifications/event_notifier/post_spec.rb
@@ -6,21 +6,55 @@ RSpec.describe ::PushNotifications::EventNotifier::Post do
   let(:post) { Fabricate(:post, organization: organization, user: user) }
   let(:event) { Fabricate.build(:event, post: post, action: :created) }
 
-  describe '#users' do
+  describe '#device_tokens' do
     context 'when a user pertains to the Post\'s organization' do
-      before { organization.members.create(user: user) }
+      let!(:member) { organization.members.create(user: user) }
 
-      context 'and the user has a DeviceToken associated' do
-        let!(:device_token) { Fabricate(:device_token, user: user, token: 'aloha') }
+      context 'and the membership is active (default)' do
+        context 'and the user\'s setting push_notifications is set to true (default)' do
+          context 'and the user has a DeviceToken associated' do
+            let!(:device_token) { Fabricate(:device_token, user: user, token: 'aloha') }
 
-        it 'returns the device token associated with the user' do
-          expect(described_class.new(event: event).device_tokens).to eq([device_token])
+            it 'returns the device token associated with the user' do
+              expect(described_class.new(event: event).device_tokens).to eq([device_token])
+            end
+          end
+
+          context 'but the user has no DeviceToken associated' do
+            it 'doesn\'t return the user' do
+              expect(described_class.new(event: event).device_tokens).to eq([])
+            end
+          end
+        end
+
+        context 'and the user\'s setting push_notifications is set to false' do
+          before do
+            user.push_notifications = false
+            user.save!
+          end
+
+          context 'and the user has a DeviceToken associated' do
+            let!(:device_token) { Fabricate(:device_token, user: user, token: 'aloha') }
+
+            it 'doesn\'t return the device token associated with the user' do
+              expect(described_class.new(event: event).device_tokens).to_not include(device_token)
+            end
+          end
         end
       end
 
-      context 'but the user has no DeviceToken associated' do
-        it 'doesn\'t return the user' do
-          expect(described_class.new(event: event).device_tokens).to eq([])
+      context 'and the membership is not active' do
+        before do
+          member.active = false
+          member.save!
+        end
+
+        context 'and the user has a DeviceToken associated' do
+          let!(:device_token) { Fabricate(:device_token, user: user, token: 'aloha') }
+
+          it 'doesn\'t return the device token associated with the user' do
+            expect(described_class.new(event: event).device_tokens).to_not include(device_token)
+          end
         end
       end
     end


### PR DESCRIPTION
### WAT
We only want to notify users that:
 - are active members of an organization
 - have `push_notifications` flag set to `true`

Fix https://github.com/coopdevs/timeoverflow/issues/381