### PR TITLE
Translate/quit app platform brands

### DIFF
--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -374,14 +374,13 @@ ca:
   pages:
     about:
       app-mobile: Aplicació Mòbil
-      app-mobile-text: L'aplicació mòbil de TimeOverflow està disponible per Android i IOS <br /> Aquesta app ha estat possible gràcies a la col·laboració de l'Ajuntament de Barcelona, a través del programa %{impulsem_link} (Barcelona Activa) 2017-2018
+      app-mobile-text: L'aplicació mòbil de TimeOverflow està disponible<br /> Aquesta app ha estat possible gràcies a la col·laboració de l'Ajuntament de Barcelona, a través del programa %{impulsem_link} (Barcelona Activa) 2017-2018
       banner-button: Sol·licita accés
       banner-subtitle: Us ajudarem a posar-lo en marxa o fer-vos una demostració
       banner-title: Ets un Banc de Temps?
       donate-link: Dona 1€ al mes
       donate-text: Amb la finalitat de donar suport a moltes comunitats la associació ADBdT ofereix la plataforma TimeOverflow a tots los Bancs de Temps. Considera %{donate_link} per contribuir a les despeses de manteniment i innovació.
       donate-title: Participa amb una donació
-      donate_link: donar 1€ al mes
       empower-adbdt: ADBdT
       empower-adbdt-title: Associació pel Desenvolupament dels Bancs de Temps
       empower-coopdevs: CoopDevs
@@ -499,9 +498,7 @@ ca:
     edit:
       edit_user: Canviar usuari
     form:
-      admin_warning: Atenció!!! Estàs atorgant poders a aquest usuari!!
       notifications: Notificacions
-      superadmin_warning: Atenció!!! Estàs atorgant PODERS DIVINS a aquest usuari!!
     give_time:
       give_time: Donar Temps a
     index:
@@ -515,6 +512,9 @@ ca:
       manage_warning_angular: Vas a canviar els permisos de l'usuari {{username}}
       members: Membres
       user_created: Usuari %{uid} %{name} guardat
+    member_card:
+      active_ago: 
+      no_activity: 
     new:
       cancel: Cancel·lar
       create_more_users_button: Crear i introduir un nou usuari

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,7 +403,7 @@ en:
       title: The software designed by and for
       title2: Time Banks
       app-mobile: Mobile App
-      app-mobile-text: The mobile app TimeOverflow for Android and iOS is available for download. <br /> This app has been possible thanks to the collaboration of the municipality of Barcelona, program %{impulsem_link} (Barcelona Activa) 2017-2018
+      app-mobile-text: The mobile app TimeOverflow is available. <br /> This app has been possible thanks to the collaboration of the municipality of Barcelona, program %{impulsem_link} (Barcelona Activa) 2017-2018
       impulsem-link: "Impulsem el que fas"
   posts:
     show:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -374,14 +374,13 @@ es:
   pages:
     about:
       app-mobile: App Móvil
-      app-mobile-text: La app móvil de TimeOverflow está disponible para Android y IOS<br /> Esta app ha sido posible gracias a la colaboración del Ayuntamiento de Barcelona, a través del programa %{impulsem_link} (Barcelona Activa) 2017-2018
+      app-mobile-text: La app móvil de TimeOverflow está disponible<br /> Esta app ha sido posible gracias a la colaboración del Ayuntamiento de Barcelona, a través del programa %{impulsem_link} (Barcelona Activa) 2017-2018
       banner-button: Solicita acceso
       banner-subtitle: Os ayudaremos a ponerlo en marcha o a haceros una demostración
       banner-title: "¿Eres un Banco de Tiempo?"
       donate-link: Donar 1€ al mes
       donate-text: Con el fin de apoyar a muchas comunidades la asociación ADBdT ofrece la plataforma TimeOverflow a todos los Bancos de Tiempo. Considera %{donate_link} para contribuir a los gastos de mantenimiento e innovación.
       donate-title: Participa con una donación
-      donate_link: donar 1€ al mes
       empower-adbdt: ADBdT
       empower-adbdt-title: Asociación para el Desarrollo de los Bancos de Tiempo
       empower-coopdevs: CoopDevs
@@ -499,9 +498,7 @@ es:
     edit:
       edit_user: Cambiar usuario
     form:
-      admin_warning: Atención!!! Estás dando poderes a este usuario!!
       notifications: Notificaciones
-      superadmin_warning: Atención!!! Estás dando PODERES DIVINOS a este usuario!!
     give_time:
       give_time: Dar Tiempo a
     index:
@@ -515,6 +512,9 @@ es:
       manage_warning_angular: Va a cambiar los privilegios del usuario {{username}}
       members: Miembros
       user_created: Usuario %{uid} %{name} guardado
+    member_card:
+      active_ago: 
+      no_activity: 
     new:
       cancel: Cancelar
       create_more_users_button: Crear e introducir otro usuario

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -387,7 +387,6 @@ eu:
       donate-link: 
       donate-text: komunitate askori babesteko asmotan ADBdt elkarteak , TimeOverflow plataforma eskaintzen die Denbora Banku guztiei. Hausnar ezazu %{donate_link}  mantenu eta berritze lanetan laguntzeko.
       donate-title: Laguntzan parte hartu
-      donate_link: Hilean €1 ematea
       empower-adbdt: ADBdt
       empower-adbdt-title: Denbora Bankuen garapenerako elkartea
       empower-coopdevs: CoopDevs
@@ -505,9 +504,7 @@ eu:
     edit:
       edit_user: Erabiltzailea aldatu
     form:
-      admin_warning: Kontuz!!! Erabiltzaile honi boterea ematen ari zara.
       notifications: Jakinarazpen
-      superadmin_warning: Kontuz!!! Erabiltzaile honi izugarrizko boterea ematen ari zara.
     give_time:
       give_time: honi denbora eman
     index:
@@ -521,6 +518,9 @@ eu:
       manage_warning_angular: " {{username}} erabiltzailearen onurak, aldatuko diztuzu"
       members: 
       user_created: "%{uid} %{name} erabiltzailea gorde da"
+    member_card:
+      active_ago: 
+      no_activity: 
     new:
       cancel: Deuseztatu
       create_more_users_button: Beste erabiltzaile bat sortu eta sartu

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -381,7 +381,6 @@ pt-BR:
       donate-link: 
       donate-text: 
       donate-title: 
-      donate_link: 
       empower-adbdt: ADBdt
       empower-adbdt-title: Associação para o Desenvolvimento dos Bancos de Tempo
       empower-coopdevs: CoopDevs
@@ -499,9 +498,7 @@ pt-BR:
     edit:
       edit_user: Trocar usuário
     form:
-      admin_warning: Atenção!!! Você está dando poderes a este usuário!!
       notifications: Notificações
-      superadmin_warning: Atenção!!! Você está dando PODERES DIVINOS a este usuário!!
     give_time:
       give_time: Dar Tempo a
     index:
@@ -515,6 +512,9 @@ pt-BR:
       manage_warning_angular: Mudará os privilégios do usuário {{username}}
       members: 
       user_created: Usuário %{uid} %{name} guardado
+    member_card:
+      active_ago: 
+      no_activity: 
     new:
       cancel: Cancelar
       create_more_users_button: Criar e introduzir outro usuário


### PR DESCRIPTION
In order to meet the Apple app store requirements we remove app platforms brand names from de copies. 

![fireshot capture 40 - app store connect_ - https___appstoreconnect apple com_](https://user-images.githubusercontent.com/2297137/45678676-4335e100-bb37-11e8-9467-74ae55d3bb55.png)