### PR TITLE
fix cancel_membership wrong key name

### DIFF
--- a/app/views/users/_cancel_membership_link.html.erb
+++ b/app/views/users/_cancel_membership_link.html.erb
@@ -3,5 +3,5 @@
             method: :delete,
             data: { confirm: t('users.user_rows.cancel_warning', user: member.username) } do %>
   <%= glyph :ban_circle %>
-  <%= t('global.cancel_member') %>
+  <%= t('global.cancel_membership') %>
 <% end %>


### PR DESCRIPTION
I noticed text of delete member text was changed some months ago, now investigating it is because of wrong key name `cancel_member` added in https://github.com/coopdevs/timeoverflow/commit/67f84238e19307165c76e5d621376c13d191bb84#diff-5aa8fc36c2410dd5d5bcaf6d22292ddd

![2018-09-20-130253_1960x2160_scrot](https://user-images.githubusercontent.com/2297137/45814564-487d6200-bcd6-11e8-9a25-1675b6784a52.png)

I restored by the old key name cancel_membership and the correct text reappeared :wink: 
![fireshot capture 48 - banco de tiempo local - http___local timeoverflow org_3000_members_manage](https://user-images.githubusercontent.com/2297137/45814674-9e520a00-bcd6-11e8-92d3-c392ec6bbe2c.png)


