### PR TITLE
Process invalid push notifications

### DIFF
--- a/app/models/push_notification.rb
+++ b/app/models/push_notification.rb
@@ -2,7 +2,8 @@ class PushNotification < ActiveRecord::Base
   belongs_to :event, foreign_key: 'event_id'
   belongs_to :device_token, foreign_key: 'device_token_id'
 
-  validates :event, :device_token, :title, presence: true
+  validates :event, :device_token, presence: true
+  validates :title, :body, presence: true, allow_blank: false
 
   delegate :token, to: :device_token
 end

--- a/db/migrate/20180924164456_process_invalid_push_notifications.rb
+++ b/db/migrate/20180924164456_process_invalid_push_notifications.rb
@@ -1,0 +1,17 @@
+class ProcessInvalidPushNotifications < ActiveRecord::Migration
+  def up
+    PushNotification.where(processed_at: nil).find_in_batches do |batch|
+      batch.each do |push_notification|
+        unless push_notification.valid?
+          now = Time.now.utc
+          push_notification.update_columns(processed_at: now, updated_at: now)
+          puts "Updating invalid PushNotification ##{push_notification.id}"
+        end
+      end
+    end
+  end
+
+  def down
+    puts 'no.'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180831161349) do
+ActiveRecord::Schema.define(version: 20180924164456) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/jobs/send_push_notifications_job_spec.rb
+++ b/spec/jobs/send_push_notifications_job_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe SendPushNotificationsJob, type: :job do
         :push_notification,
         event: event_created,
         device_token: device_token,
-        title: 'A new Post hase been created.'
+        title: 'A new Post hase been created.',
+        body: 'A push notification body.'
       )
     end
     let(:processed_push_notification) do
@@ -21,6 +22,7 @@ RSpec.describe SendPushNotificationsJob, type: :job do
         event: event_updated,
         device_token: device_token,
         title: 'A new Post hase been created.',
+        body: 'A push notification body.',
         processed_at: Time.zone.now
       )
     end

--- a/spec/models/push_notification_spec.rb
+++ b/spec/models/push_notification_spec.rb
@@ -1,10 +1,40 @@
 require 'spec_helper'
 
 RSpec.describe PushNotification do
+  let!(:event) { Fabricate.build(:event) }
+  let!(:device_token) { Fabricate.build(:device_token, token: 'token') }
+  let!(:push_notification) { described_class.new(device_token: device_token) }
+
   describe 'Validations' do
     it { is_expected.to validate_presence_of(:event) }
     it { is_expected.to validate_presence_of(:device_token) }
     it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:body) }
+  end
+
+  describe 'Not blank validations' do
+    let(:valid_push_notification) {
+      PushNotification.new(
+        event: event,
+        device_token: device_token,
+        title: "A title",
+        body: "A body"
+      )
+    }
+
+    it 'validates non blank fields' do
+      expect(valid_push_notification).to be_valid
+
+      valid_push_notification.tap do |with_blank_title|
+        with_blank_title.title = ''
+        expect(with_blank_title).to_not be_valid
+      end
+
+      valid_push_notification.tap do |with_blank_body|
+        with_blank_body.body = ''
+        expect(with_blank_body).to_not be_valid
+      end
+    end
   end
 
   describe 'Associations' do
@@ -16,9 +46,6 @@ RSpec.describe PushNotification do
   end
 
   describe "#token" do
-    let(:device_token) { Fabricate.build(:device_token, token: 'token') }
-    let(:push_notification) { described_class.new(device_token: device_token) }
-
     it 'returns the associated DeviceToken\'s token' do
       expect(push_notification.token).to eq('token')
     end


### PR DESCRIPTION
In order to send a PushNotification, the model must have non blank `title` and `body`. While testing the PushNotification creator we created some invalid models in production (and probably other envs).

Here I'm adding the validations and a migration to mark those invalid notifications as *processed*.