### PR TITLE
Little improvements in /members

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,8 +2,7 @@ class UsersController < ApplicationController
   before_filter :authenticate_user!
 
   def index
-    # I would like nulls to go last but ransack... https://github.com/activerecord-hackery/ransack/issues/443
-    search_and_load_members current_organization.members.active, {s: 'user_last_sign_in_at desc'}
+    search_and_load_members current_organization.members.active, {s: 'member_uid asc'}
   end
 
   def manage

--- a/app/views/users/_member_card.html.erb
+++ b/app/views/users/_member_card.html.erb
@@ -19,20 +19,12 @@
         <%= member.description&.truncate(124) %>
       </div>
       <div class="to-member-card__body__items">
-        <div class="to-member-card__body__item">
-          <span class="glyphicon glyphicon-earphone"></span>
-          <%= phone_to member.phone %>
-        </div>
-        <div class="to-member-card__body__item">
-          <span class="glyphicon glyphicon-envelope"></span>
-          <%= member.mail_to %>
-        </div>
-      </div>
-      <div class="to-member-card__body__items">
-        <div class="to-member-card__body__item">
-          <span class="glyphicon glyphicon-earphone"></span>
-          <%= phone_to member.phone %>
-        </div>
+        <% if member.phone && !member.phone.blank? %>
+          <div class="to-member-card__body__item">
+            <span class="glyphicon glyphicon-earphone"></span>
+            <%= phone_to member.phone %>
+          </div>
+        <% end %>
         <div class="to-member-card__body__item">
           <span class="glyphicon glyphicon-envelope"></span>
           <%= member.mail_to %>

--- a/app/views/users/_member_card.html.erb
+++ b/app/views/users/_member_card.html.erb
@@ -25,10 +25,12 @@
             <%= phone_to member.phone %>
           </div>
         <% end %>
-        <div class="to-member-card__body__item">
-          <span class="glyphicon glyphicon-envelope"></span>
-          <%= member.mail_to %>
-        </div>
+        <% if member.mail_to.present? && !member.mail_to.blank? %>
+          <div class="to-member-card__body__item">
+            <span class="glyphicon glyphicon-envelope"></span>
+            <%= member.mail_to %>
+          </div>
+        <% end %>
         <div class="to-member-card__body__item">
           <%= "Balance: " %>
           <%= member.account_balance %>

--- a/app/views/users/_member_card.html.erb
+++ b/app/views/users/_member_card.html.erb
@@ -16,7 +16,17 @@
     </div>
     <div class="to-member-card__body">
       <div class="to-member-card__body__description">
-        <%= member.description %>
+        <%= member.description&.truncate(124) %>
+      </div>
+      <div class="to-member-card__body__items">
+        <div class="to-member-card__body__item">
+          <span class="glyphicon glyphicon-earphone"></span>
+          <%= phone_to member.phone %>
+        </div>
+        <div class="to-member-card__body__item">
+          <span class="glyphicon glyphicon-envelope"></span>
+          <%= member.mail_to %>
+        </div>
       </div>
       <div class="to-member-card__body__items">
         <div class="to-member-card__body__item">

--- a/app/views/users/_member_card.html.erb
+++ b/app/views/users/_member_card.html.erb
@@ -19,7 +19,7 @@
         <%= member.description&.truncate(124) %>
       </div>
       <div class="to-member-card__body__items">
-        <% if member.phone && !member.phone.blank? %>
+        <% if member.phone.present? && !member.phone.blank? %>
           <div class="to-member-card__body__item">
             <span class="glyphicon glyphicon-earphone"></span>
             <%= phone_to member.phone %>

--- a/app/views/users/_user_row.html.erb
+++ b/app/views/users/_user_row.html.erb
@@ -5,11 +5,11 @@
     <%= member.inactive_icon %>
     <%= member.link_to_self %>
   </td>
-  <td class="hidden-xs"> <%= member.mail_to %> </td>
-  <td class="hidden-xs hidden-sm"> <%= phone_to member.phone %> </td>
-  <td class="hidden-xs hidden-sm"> <%= member.account_balance %> </td>
+  <td> <%= member.mail_to %> </td>
+  <td> <%= phone_to member.phone %> </td>
+  <td> <%= member.account_balance %> </td>
   <% if current_user.manages?(current_organization) %>
-    <td class="hover-actions hidden-xs hidden-sm">
+    <td class="hover-actions">
       <% if member.active? %>
         <%= render 'toggle_manager_link', member: member if can_toggle_manager?(member) %>
       <% else %>

--- a/app/views/users/manage.html.erb
+++ b/app/views/users/manage.html.erb
@@ -50,17 +50,17 @@
               <th>
                 <%= sort_link @search, :user_username, User.human_attribute_name(:username) %>
               </th>
-              <th class="hidden-xs">
+              <th>
                 <%= User.human_attribute_name(:email) %>
               </th>
-              <th class="hidden-xs hidden-sm">
+              <th>
                 <%= User.human_attribute_name(:phone) %>
               </th>
-              <th class="hidden-xs hidden-sm">
+              <th>
                 <%= sort_link @search, 'account_balance', Account.human_attribute_name(:balance) %>
               </th>
               <% if current_user.manages? current_organization %>
-                <th class="hidden-xs hidden-sm">
+                <th>
                   <span class="glyphicon glyphicon-hand-down"></span>
                   <%= t(".actions") %>
                 </th>

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -40,12 +40,16 @@ RSpec.describe UsersController do
   describe "GET #index" do
     before { login(user) }
 
-    it 'sorts the users by their member_uid asc by default' do
+    it 'sorts the users by their user_last_sign_in_at desc by default' do
       member.increment!(:member_uid, Member.maximum(:member_uid) + 1)
+      member.user.update_attribute(
+        :last_sign_in_at,
+        DateTime.now
+      )
 
       get :index
 
-      expect(assigns(:members).last).to eq(member)
+      expect(assigns(:members).first).to eq(member)
     end
 
     it 'allows to sort by member_uid' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -40,16 +40,12 @@ RSpec.describe UsersController do
   describe "GET #index" do
     before { login(user) }
 
-    it 'sorts the users by their user_last_sign_in_at desc by default' do
+    it 'sorts the users by their member_uid asc by default' do
       member.increment!(:member_uid, Member.maximum(:member_uid) + 1)
-      member.user.update_attribute(
-        :last_sign_in_at,
-        DateTime.now
-      )
 
       get :index
 
-      expect(assigns(:members).first).to eq(member)
+      expect(assigns(:members).last).to eq(member)
     end
 
     it 'allows to sort by member_uid' do

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -10,6 +10,7 @@ Fabricator(:user) do
   address { Faker::Address.street_address + " " + Faker::Address.zip_code + " " + Faker::Address.city + " (" + Faker::Address.state + ")"}
   gender { ["male", "female"].shuffle.first }
   description { Faker::Lorem.paragraph }
+  last_sign_in_at { DateTime.new(2018, 10, 1) }
 
   terms_accepted_at DateTime.now.utc
   confirmed_at DateTime.now.utc


### PR DESCRIPTION
- Do not hide actions in the manage users page
- Sort members by last_sign_in_at
- Truncate member description
- Hide telephone icon when there is no phone number