### PR TITLE
Return a default description when it is empty

### DIFF
--- a/app/services/push_notifications/creator/post.rb
+++ b/app/services/push_notifications/creator/post.rb
@@ -8,7 +8,13 @@ module PushNotifications
       end
 
       def body
-        event.post.description&.truncate(20) || 'No description'
+        description = event.post.description
+
+        if description.blank?
+          'No description'
+        else
+          description.truncate(20)
+        end
       end
 
       def data

--- a/spec/services/push_notifications/post_spec.rb
+++ b/spec/services/push_notifications/post_spec.rb
@@ -13,10 +13,71 @@ RSpec.describe PushNotifications::Creator::Post do
   end
 
   describe '#create!' do
-    it 'creates as many PushNotification resources as needed' do
-      expect {
-        creator.create!
-      }.to change{PushNotification.count}.by(1)
+    context 'integration' do
+      it 'creates as many PushNotification resources as needed' do
+        expect { creator.create! }.to change { PushNotification.count }.by(1)
+      end
+    end
+
+    context 'unit' do
+      let(:post) do
+        Fabricate(
+          :post,
+          organization: organization,
+          user: user,
+          description: description
+        )
+      end
+
+      before { allow(PushNotification).to receive(:create!) }
+
+      context 'when the post description is empty' do
+        let(:description) { '' }
+
+        it 'creates a PushNotification with a default body' do
+          creator.create!
+
+          expect(PushNotification)
+            .to have_received(:create!)
+            .with(include(body: 'No description'))
+        end
+      end
+
+      context 'when the post description is nil' do
+        let(:description) { nil }
+
+        it 'creates a PushNotification with a default body' do
+          creator.create!
+
+          expect(PushNotification)
+            .to have_received(:create!)
+            .with(include(body: 'No description'))
+        end
+      end
+
+      context 'when the post description is shorter than 20 chars' do
+        let(:description) { 'description' }
+
+        it 'creates a PushNotification with the post body' do
+          creator.create!
+
+          expect(PushNotification)
+            .to have_received(:create!)
+            .with(include(body: post.description))
+        end
+      end
+
+      context 'when the post description is larger than 20 chars' do
+        let(:description) { 'this is a very long description' }
+
+        it 'creates a PushNotification with the post body truncated' do
+          creator.create!
+
+          expect(PushNotification)
+            .to have_received(:create!)
+            .with(include(body: post.description.truncate(20)))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes the following error spotted in Sidekiq web UI. See below

![screenshot from 2018-09-27 13-13-35](https://user-images.githubusercontent.com/762088/46142413-2a27e100-c257-11e8-884c-d44512c256de.png)
