### PR TITLE
Add docker compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ruby:2.3.0
+
+# Install essential Linux packages
+RUN apt-get update -qq && apt-get install -y \
+    build-essential \
+    libpq-dev \
+    postgresql-client \
+    nodejs
+
+WORKDIR /app
+
+# Copy Gemfile and Gemfile.lock
+COPY Gemfile* /app/
+
+# Speed up nokogiri install
+ENV NOKOGIRI_USE_SYSTEM_LIBRARIES 1
+
+RUN bundle install
+
+# Copy the Rails application into place
+COPY . /app
+
+#CMD [ "rails", "server", "-b", "3000" ]
+#CMD [ "bundle", "exec", "puma" ]

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-ruby File.read('.ruby-version').strip
 
 gem 'rails', '~> 4.2'
 gem 'rails-i18n'

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,6 +11,7 @@
 #
 
 defaults: &defaults
+  host: <%= ENV['DATABASE_HOST'] || "localhost" %>  # use localhost as fallback
   adapter: postgresql
   username: <%= ENV['DATABASE_USER'] %>  # default is null
   collation: 'es_ES.UTF-8'

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,8 +14,8 @@ defaults: &defaults
   host: <%= ENV['DATABASE_HOST'] || "localhost" %>  # use localhost as fallback
   adapter: postgresql
   username: <%= ENV['DATABASE_USER'] %>  # default is null
-  collation: 'es_ES.UTF-8'
-  ctype: 'es_ES.UTF-8'
+  #collation: 'es_ES.UTF-8'
+  #ctype: 'es_ES.UTF-8'
   template: 'template0'
   encoding: utf8
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - redis
     volumes:
       - "./:/app"
     command: rails server -p 3000 -b '0.0.0.0'
@@ -30,6 +31,8 @@ services:
     build: .
     env_file: .env
     command: bundle exec sidekiq
+    depends_on:
+      - redis
     environment:
       DATABASE_HOST: db
       REDIS_URL: redis://redis:6379/0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,13 +24,23 @@ services:
     environment:
       DATABASE_HOST: db
       REDIS_URL: redis://redis:6379/0
+      ELASTICSEARCH_URL: elasticsearch:9200
 
   sidekiq:
     build: .
     env_file: .env
     command: bundle exec sidekiq
     environment:
+      DATABASE_HOST: db
       REDIS_URL: redis://redis:6379/0
+      ELASTICSEARCH_URL: elasticsearch:9200
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+    ports:
+      - 9200:9200
+    environment:
+      - "discovery.type=single-node"
 
 #  web:
 #    image: nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.3'
+
+services:
+  db:
+    image: postgres:9
+    volumes:
+      - postgres-volume:/var/lib/postgresql/data
+
+  redis:
+    image: redis:4
+    ports:
+      - "6379:6379"
+
+  app:
+    build: .
+    env_file: .env
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+    volumes:
+      - "./:/app"
+    command: rails server -p 3000 -b '0.0.0.0'
+    environment:
+      DATABASE_HOST: db
+      REDIS_URL: redis://redis:6379/0
+
+  sidekiq:
+    build: .
+    env_file: .env
+    command: bundle exec sidekiq
+    environment:
+      REDIS_URL: redis://redis:6379/0
+
+#  web:
+#    image: nginx
+#    depends_on:
+#      - app
+#    ports:
+#      - 80:80
+#      #- 443:443
+
+volumes:
+  postgres-volume:


### PR DESCRIPTION
Hi, new contributor here!

I use **Docker** a lot and wanted to help out this project by making it easier to start up.


In this PR start with:
   `docker-compose up`  

And setup the db (only once) with
  `docker-compose exec app rake db:setup`



### Files changed:

1. `config/database.yml`

This could be a separate issue but Database creation fails on non-docker on my Ubuntu 16 machine with 
``` Couldn't create database for {"adapter"=>"postgresql", "username"=>"postgres", "collation"=>"es_ES.UTF-8", "ctype"=>"es_ES.UTF-8", "template"=>"template0", "encoding"=>"utf8", "host"=>"localhost", "database"=>"timeoverflow_development"}
PG::WrongObjectType: ERROR:  invalid locale name: "es_ES.UTF-8"
: CREATE DATABASE "timeoverflow_test" ENCODING = 'utf8' LC_COLLATE = 'es_ES.UTF-8' LC_CTYPE = 'es_ES.UTF-8' TEMPLATE = "template0"
```
This fails both in docker and non-docker environments. I 'fixed' this by commenting out `ctype` and `collation` in `config/database.yml` - We can add that as an ENV?

2. `Gemfile` 
* Having this in the Gemfile: 
`ruby File.read('.ruby-version').strip` 
does not work with Docker,  I removed it in this PR. It was introduced in #341
* Rails 5.2 projects will have the `ruby 'version'`  directly https://github.com/rails/rails/pull/30016
* I think we should do the same and add the string directly. I can create a different PR for that


### Tests
Tests can be run with `docker-compose exec app rake`

Currently **6** tests fail:
   **2** fail with this [known issue](https://github.com/elastic/elasticsearch-rails/issues/756) and might be fixed by updating the elasticsearch gems:
```
    Elasticsearch::Transport::Transport::Errors::NotAcceptable:
       [406] {"error":"Content-Type header [application/x-www-form-urlencoded] is not supported","status":406}
```

**4** fail with:
```
     Selenium::WebDriver::Error::WebDriverError:
     unable to connect to chromedriver 127.0.0.1:9515
```

#### Elastic search
Which version of elasticsearch are we using in prod?
   * We can imitate that by telling `docker-compose.yml` which version we want.


#### Instructions
Should we add instructions to the wiki or to the README?
I think basic instructions can live in the main README

**Notes:**
This is partly based on an older incomplete pr #187 