### PR TITLE
Travis reads the .ruby-version file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 cache: bundler
 bundler_args: '--without production development'
-#rvm:
-  #- 2.3.0
 env: DATABASE_URL=postgres://postgres@localhost/timeoverflow_test
 before_script:
   - bundle exec rake db:setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 cache: bundler
 bundler_args: '--without production development'
-rvm:
-  - 2.3.0
+#rvm:
+  #- 2.3.0
 env: DATABASE_URL=postgres://postgres@localhost/timeoverflow_test
 before_script:
   - bundle exec rake db:setup


### PR DESCRIPTION
No need to have it manually in the .travis.yml

> If the ruby version is not specified by the rvm key, Travis CI uses the version specified in the .ruby-version file in the root of the repository if one is available.