### PR TITLE
Small controllers refactor

### DIFF
--- a/app/controllers/global_controller.rb
+++ b/app/controllers/global_controller.rb
@@ -1,5 +1,0 @@
-class GlobalController < ApplicationController
-  def switch_lang
-    redirect_to :back
-  end
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
   ActiveAdmin.routes(self)
 
-  get "global/switch_lang", as: :switch_lang
+  get :switch_lang, to: 'application#switch_lang'
 
   get "/pages/:page" => "pages#show", as: :page
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe ApplicationController do
+  describe '#switch_lang' do
+    let(:original_locale) { I18n.locale }
+
+    before do
+      request.env["HTTP_REFERER"] = root_path
+    end
+
+    after do
+      I18n.locale = original_locale
+    end
+
+    it 'switches locale to passed language via params' do
+      new_locale = (I18n.available_locales - [original_locale]).sample
+
+      expect do
+        get :switch_lang, locale: new_locale
+      end.to change(I18n, :locale).from(original_locale).to(new_locale)
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+end


### PR DESCRIPTION
## WAT?
Couple of minor cleanups:

- removed unused store_location: #249 has been closed, so there is no point of maintaining a `session[:previous_url]` right now

- moved `switch_lang` action to `ApplicationController` + added spec: => :scissors: `GlobalController` that only handles this action, so I think it's fine (and simpler) to move it to main/app controller 

## TESTING
- We just need to test the language switcher