### PR TITLE
Enable partial word searches in pg_search

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,8 +3,11 @@ class Post < ActiveRecord::Base
   include PgSearch
 
   pg_search_scope :search_by_query,
-    :against => [:title, :description, :tags],
-    :ignoring => :accents
+    against: [:title, :description, :tags],
+    ignoring: :accents,
+    using: {
+      tsearch: { prefix: true }
+    }
 
   attr_reader :member_id
 

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -36,14 +36,20 @@ RSpec.describe OffersController, type: :controller do
   end
 
   describe "GET #index (search)" do
-    it "populates an array of offers" do
-      login(another_member.user)
+    before { login(another_member.user) }
 
+    it "populates an array of offers" do
       get "index", q: offer.title.split(/\s/).first
 
       expect(assigns(:offers).size).to eq 1
       expect(assigns(:offers)[0]).to eq offer
       expect(assigns(:offers).to_a).to eq([offer])
+    end
+
+    it "allows to search by partial word" do
+      get :index, q: offer.title.split(/\s/).first[0..-2]
+
+      expect(assigns(:offers)).to include offer
     end
   end
 


### PR DESCRIPTION
:eyes: :point_right: Target branch: `feature/switch-from-elastic-to-pg-search-la-buena` (#465)

---

Enable partial word searches in pg_search.
 
Doc: https://github.com/Casecommons/pg_search#prefix-postgresql-84-and-newer-only