### PR TITLE
Report code coverage (via Code Climate) in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
+env:
+  global:
+    - CC_TEST_REPORTER_ID=XXXXXXX
 language: ruby
 cache: bundler
 bundler_args: '--without development'
 env: DATABASE_URL=postgres://postgres@localhost/timeoverflow_test
 before_script:
   - bundle exec rake db:setup
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
   # allow elasticsearch to be ready - https://docs.travis-ci.com/user/database-setup/#ElasticSearch
   - sleep 10
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 services:
   - elasticsearch
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-env:
-  global:
-    - CC_TEST_REPORTER_ID=XXXXXXX
 language: ruby
 cache: bundler
 bundler_args: '--without development'
-env: DATABASE_URL=postgres://postgres@localhost/timeoverflow_test
+env:
+  global:
+    - DATABASE_URL=postgres://postgres@localhost/timeoverflow_test
+    - CC_TEST_REPORTER_ID=025bc15a0fa9afa52d86ee24fea845cf1d363f48a466bcf2cef8ab80c29acb28
 before_script:
   - bundle exec rake db:setup
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# TimeOverflow [![View performance data on Skylight](https://badges.skylight.io/problem/grDTNuzZRnyu.svg)](https://oss.skylight.io/app/applications/grDTNuzZRnyu) [![Build Status](https://travis-ci.org/coopdevs/timeoverflow.svg)](https://travis-ci.org/coopdevs/timeoverflow) [![Code Climate](https://codeclimate.com/github/timeoverflow/timeoverflow/badges/gpa.svg)](https://codeclimate.com/github/timeoverflow/timeoverflow)
+# TimeOverflow
+[![View performance data on Skylight](https://badges.skylight.io/problem/grDTNuzZRnyu.svg)](https://oss.skylight.io/app/applications/grDTNuzZRnyu)
+[![Build Status](https://travis-ci.org/coopdevs/timeoverflow.svg)](https://travis-ci.org/coopdevs/timeoverflow)
+[![Maintainability](https://api.codeclimate.com/v1/badges/f82c6d98a2441c84f2ef/maintainability)](https://codeclimate.com/github/coopdevs/timeoverflow/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/f82c6d98a2441c84f2ef/test_coverage)](https://codeclimate.com/github/coopdevs/timeoverflow/test_coverage)
+
 #### www.timeoverflow.org
 
 :globe_with_meridians: Read this [in English](docs/README.en.md)


### PR DESCRIPTION
Closes #281
Closes #476
Closes #483

:information_source: Docs: https://docs.codeclimate.com/docs/travis-ci-test-coverage#section-travis-ci-single-test-suite-non-parallel-builds

Pending:
- [x] Add ENV var `CC_TEST_REPORTER_ID`
- [x] Add coverage report badge in README