### PR TITLE
remove destination accountable from transfer sources options

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -40,7 +40,7 @@ class Member < ActiveRecord::Base
   # @params _destination_accountable used to keep the same API as
   #   Organization#display_id
   # @return [Integer]
-  def display_id(_destination_accountable)
+  def display_id
     member_uid
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -29,12 +29,8 @@ class Organization < ActiveRecord::Base
   #
   # @params destination_accountable [Organization | Object] target of a transfer
   # @return [Integer | String]
-  def display_id(destination_accountable)
-    if destination_accountable.is_a?(Organization)
-      account.accountable_id
-    else
-      ''
-    end
+  def display_id
+    account.accountable_id
   end
 
   def ensure_reg_number_seq!

--- a/app/models/transfer_sources_options.rb
+++ b/app/models/transfer_sources_options.rb
@@ -4,10 +4,8 @@ class TransferSourcesOptions
   # Constructor
   #
   # @param sources [Array<Account>]
-  # @param destination_accountable [Member | Organization]
-  def initialize(sources, destination_accountable)
+  def initialize(sources)
     @sources = sources
-    @destination_accountable = destination_accountable
   end
 
   # Returns the collection as an Array containing pairs of <option>'s text and
@@ -22,7 +20,7 @@ class TransferSourcesOptions
 
   private
 
-  attr_reader :sources, :destination_accountable
+  attr_reader :sources
 
   def to_accountable_type_and_uid(account)
     [account.accountable_type, account.accountable.try(:member_uid)]
@@ -32,12 +30,8 @@ class TransferSourcesOptions
     accountable = account.accountable
 
     [
-      "#{display_id(accountable)} #{accountable.class} #{accountable}",
+      "#{accountable.display_id} #{accountable.class} #{accountable}",
       account.id
     ]
-  end
-
-  def display_id(accountable)
-    accountable.display_id(destination_accountable)
   end
 end

--- a/app/views/transfers/_sources.html.erb
+++ b/app/views/transfers/_sources.html.erb
@@ -2,7 +2,7 @@
   <%= form.label :source %>
   <%= form.select :source,
     options_for_select(
-      TransferSourcesOptions.new(sources, accountable).to_a,
+      TransferSourcesOptions.new(sources).to_a,
       selected: current_user.member(current_organization).account.id
     ), {}, id: "select2-time", class: "form-control"
   %>

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe TransfersController do
           get :new, params
 
           expect(response.body).to include("<select id=\"select2-time\" class=\"form-control\" name=\"transfer[source]\"><option selected=\"selected\" value=\"#{member_admin.account.id}\">#{member_admin.member_uid} Member #{member_admin}</option>")
-          expect(response.body).to include("<option value=\"#{test_organization.account.id}\"> Organization #{test_organization}</option></select>")
+          expect(response.body).to include("<option value=\"#{test_organization.account.id}\">#{test_organization.id} Organization #{test_organization}</option></select>")
         end
       end
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Member do
   end
 
   describe '#display_id' do
-    subject { member.display_id(nil) }
+    subject { member.display_id }
 
     it { is_expected.to eq(member.member_uid) }
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -4,17 +4,9 @@ RSpec.describe Organization do
   let(:organization) { Fabricate(:organization) }
 
   describe '#display_id' do
-    subject { organization.display_id(destination_accountable) }
+    subject { organization.display_id }
 
-    context 'when the destination_accountable is an organization' do
-      let(:destination_accountable) { Fabricate(:organization) }
-      it { is_expected.to eq(organization.account.accountable_id) }
-    end
-
-    context 'when the destination_accountable is not an organization' do
-      let(:destination_accountable) { Fabricate(:member) }
-      it { is_expected.to eq('') }
-    end
+    it { is_expected.to eq(organization.account.accountable_id) }
   end
 
   describe 'ensure_url validation' do

--- a/spec/models/transfer_sources_options_spec.rb
+++ b/spec/models/transfer_sources_options_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe TransferSourcesOptions do
   let(:transfer_sources_options) do
-    described_class.new(sources, destination_accountable)
+    described_class.new(sources)
   end
 
   describe '#to_a' do
@@ -13,8 +13,6 @@ RSpec.describe TransferSourcesOptions do
     let(:newer_member) do
       Fabricate(:member, organization: organization, member_uid: 1)
     end
-
-    let(:destination_accountable) { Fabricate(:organization) }
 
     let(:sources) do
       [organization.account, member.account, newer_member.account]


### PR DESCRIPTION
Working on the multitransfers feature, I needed to use TransferSourcesOptions. In the context of that feature, when using TransferSourcesOptions, we don't know the destination accountable beforehand.

This PR removes the dependency on a destination accountable.