### PR TITLE
Remove deprecated attributes in posts table (closes #471)

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -106,9 +106,8 @@ class PostsController <  ApplicationController
   end
 
   def post_params
-    permitted_fields = [:description, :end_on, :global, :joinable, :permanent,
-                        :start_on, :title, :category_id, :user_id, :is_group,
-                        :active, tag_list: []]
+    permitted_fields = [:description, :end_on, :start_on, :title, :category_id,
+                        :user_id, :is_group, :active, tag_list: []]
 
     params.fetch(resource, {}).permit(*permitted_fields).tap do |p|
       set_user_id(p)

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -43,8 +43,6 @@ ca:
         created_at: Creat
         description: Descripció
         end_on: Finalitza al
-        joinable: Es poden afegir altres
-        permanent: Permanent
         start_on: Comença al
         tag_list: Etiquetes
         title: Títol

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,8 +43,6 @@ en:
         created_at: Created
         description: Description
         end_on: Ends on
-        joinable: Can join others
-        permanent: Permanent
         start_on: Start on
         tag_list: Tags
         title: Title

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -43,8 +43,6 @@ es:
         created_at: Creado
         description: Descripción
         end_on: Termina el
-        joinable: Se puede unir otros
-        permanent: Permanente
         start_on: Empieza el
         tag_list: Etiquetas
         title: Título

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -45,8 +45,6 @@ eu:
         created_at: Sortua
         description: Deskribapena
         end_on: Bukatuko da.
-        joinable: Beste batzuk gehi litezke.
-        permanent: Iraunkorra
         start_on: Hasiko da
         tag_list: Etiketa
         title: Izenburua

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -43,8 +43,6 @@ gl:
         created_at: Creado
         description: Descrición
         end_on: Termina en
-        joinable: Poden unirse outros
-        permanent: Permanente
         start_on: Comezar
         tag_list: Etiquetas
         title: Título

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -43,8 +43,6 @@ pt-BR:
         created_at: Criado
         description: Descrição
         end_on: 'Terminar o '
-        joinable: É possível unir outros
-        permanent: Permanente
         start_on: Começa o
         tag_list: Etiquetas
         title: Título

--- a/db/migrate/20190411192828_remove_deprecated_attributes_from_posts.rb
+++ b/db/migrate/20190411192828_remove_deprecated_attributes_from_posts.rb
@@ -1,0 +1,7 @@
+class RemoveDeprecatedAttributesFromPosts < ActiveRecord::Migration
+  def change
+    remove_column :posts, :permanent
+    remove_column :posts, :joinable
+    remove_column :posts, :global
+  end
+end

--- a/db/migrate/20190412163011_remove_user_joined_post_table.rb
+++ b/db/migrate/20190412163011_remove_user_joined_post_table.rb
@@ -1,0 +1,5 @@
+class RemoveUserJoinedPostTable < ActiveRecord::Migration
+  def change
+    drop_table :user_joined_post
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190411192828) do
+ActiveRecord::Schema.define(version: 20190412163011) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -175,11 +175,6 @@ ActiveRecord::Schema.define(version: 20190411192828) do
 
   add_index "transfers", ["operator_id"], name: "index_transfers_on_operator_id", using: :btree
   add_index "transfers", ["post_id"], name: "index_transfers_on_post_id", using: :btree
-
-  create_table "user_joined_post", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "post_id"
-  end
 
   create_table "users", force: :cascade do |t|
     t.string   "username",                              null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190322180602) do
+ActiveRecord::Schema.define(version: 20190411192828) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,9 +141,6 @@ ActiveRecord::Schema.define(version: 20190322180602) do
     t.text     "description"
     t.date     "start_on"
     t.date     "end_on"
-    t.boolean  "permanent"
-    t.boolean  "joinable"
-    t.boolean  "global"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "tags",                            array: true

--- a/spec/fabricators/post_fabricator.rb
+++ b/spec/fabricators/post_fabricator.rb
@@ -4,9 +4,6 @@ Fabricator(:post) do
   user { Fabricate(:user) }
   description { Faker::Lorem.paragraph }
   category { Fabricate(:category) }
-  permanent { false }
-  joinable { false }
-  global { false }
   active { true }
 
 end
@@ -19,9 +16,6 @@ Fabricator(:inquiry) do
   user { Fabricate(:user) }
   description { Faker::Lorem.paragraph }
   category { Fabricate(:category) }
-  permanent { false }
-  joinable { false }
-  global { false }
   active { true }
 
 end
@@ -34,9 +28,6 @@ Fabricator(:offer) do
   user { Fabricate(:user) }
   description { Faker::Lorem.paragraph }
   category { Fabricate(:category) }
-  permanent { false }
-  joinable { false }
-  global { false }
   active { true }
 
 end


### PR DESCRIPTION
Closes #471 

Yep, those attributes are unused by the application :fire:  

In addition, these 2 i18n keys can be also deleted:
- activerecord.attributes.post.joinable
- activerecord.attributes.post.permanent

---
**EXTRA EXTRA** remove also an unused table: https://github.com/coopdevs/timeoverflow/pull/492/commits/3506af36f6ea7c84c9ced34f3ed77d770ed6b81e

