### PR TITLE
Remove plpgsql PostgreSQL extension

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,6 @@
 ActiveRecord::Schema.define(version: 20190412163011) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
   enable_extension "hstore"
   enable_extension "pg_trgm"
 


### PR DESCRIPTION
It was added in the very beginning of the project in commit `e37eb7d` but it doesn't seem to be used anywhere. Leftovers of an old copy-paste?

cc @markets @enricostano 