### PR TITLE
Remove pg_trgm PostgreSQL extension

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,6 @@ ActiveRecord::Schema.define(version: 20190412163011) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "hstore"
-  enable_extension "pg_trgm"
 
   create_table "accounts", force: :cascade do |t|
     t.integer  "accountable_id"


### PR DESCRIPTION
No need to install this extension used by full-text search until we don't replace ElasticSearch with it.

Still, it was added in `f514c35` in the early days (2013) for user search but it doesn't seem to be used.

You @enricostano and @markets might now better.