### PR TITLE
Add spec for brand logo case when no user is signed in

### DIFF
--- a/spec/features/brand_logo_spec.rb
+++ b/spec/features/brand_logo_spec.rb
@@ -39,3 +39,23 @@ RSpec.feature 'sign in' do
   end
 end
 
+RSpec.feature 'sign out' do
+  let!(:user) do
+    Fabricate(
+      :user,
+      email: 'user@timeoverflow.org',
+      password: 'papapa22',
+      terms_accepted_at: 1.day.from_now
+    )
+  end
+
+  context 'without a user' do
+    it 'does not render the logo' do
+      sign_in_with(user.email, user.password)
+      click_link user.email
+      click_link I18n.t('application.navbar.sign_out')
+
+      expect(page).to have_no_css('.organization-brand-logo')
+    end
+  end
+end


### PR DESCRIPTION
Fix for #475 

Adds a test case for the scenario of no user being signed in (handled by BrandLogoHelper's `should_render_logo?` private method)