### PR TITLE
Do not reinstall PostgreSQL 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ services:
   - elasticsearch
 addons:
   postgresql: "9.4"
-  apt:
-    packages:
-      - postgresql-9.4
-      - postgresql-client-9.4
   chrome: stable
 bundler_args: '--without development'
 env:


### PR DESCRIPTION
It comes installed in Travis CI boxes. This might fix the service start, which is currently timing out. See details: https://github.com/coopdevs/timeoverflow/pull/525#issuecomment-561546558