### PR TITLE
Require capistrano/rbenv always

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -16,11 +16,7 @@ require 'capistrano/deploy'
 #   https://github.com/capistrano/passenger
 #
 require 'capistrano/rails'
-
-stage = ARGV.first
-if stage != 'production' # Sorry, production is not ready yet
-  require 'capistrano/rbenv'
-end
+require 'capistrano/rbenv'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }


### PR DESCRIPTION
The new production server does work the same way as staging and this hack is not needed anymore.