### PR TITLE
Remove next environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -33,7 +33,3 @@ staging:
 production:
   <<: *defaults
   database: <%= ENV.fetch('DATABASE_NAME', 'timeoverflow_production') %>
-
-next:
-  <<: *defaults
-  database: <%= ENV.fetch('DATABASE_NAME', 'timeoverflow_production') %>

--- a/config/deploy/next.rb
+++ b/config/deploy/next.rb
@@ -1,1 +1,0 @@
-server 'next.timeoverflow.org', user: 'timeoverflow', roles: %w(app db web)

--- a/config/environments/next.rb
+++ b/config/environments/next.rb
@@ -1,1 +1,0 @@
-config/environments/production.rb

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -9,6 +9,3 @@ staging:
 
 production:
   secret_key_base: <%= ENV['SECRET_TOKEN'] %>
-
-next:
-  secret_key_base: <%= ENV['SECRET_TOKEN'] %>


### PR DESCRIPTION
It was used while migration the production server and since this one and production configs are almost exact copies (just rails_env differs) it's no longer needed.

And this brings simplicity back to this repo.

The most noticeable change is the removal of `url` from production's database config as DATABASE_URL got removed in https://github.com/coopdevs/timeoverflow-provisioning/pull/21 two years ago and it's true in production:

```
timeoverflow@timeoverflow-production:~$ env | grep DATABASE
DATABASE_NAME=xxx
DATABASE_USER=xxx
DATABASE_PASSWORD=xxx
```