### PR TITLE
Replace DATABASE_URL with DATABASE_NAME

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -31,8 +31,8 @@ staging:
   database: <%= ENV.fetch('DATABASE_NAME', 'timeoverflow_staging') %>
 
 production:
-  # Set DATABASE_URL environment variable
-  url: <%= ENV['DATABASE_URL'] %>
+  <<: *defaults
+  database: <%= ENV.fetch('DATABASE_NAME', 'timeoverflow_production') %>
 
 next:
   <<: *defaults


### PR DESCRIPTION
We used to connect to it through the PostgreSQL URL but that ENV var is no longer present in the server and we have `DATABASE_NAME` instead. That's what we already used successfully with the `next` environment.

This is required to deploy using the `production` environment or the app won't be able to connect to the DB.