### PR TITLE
Set default.locale to en

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,8 @@ Rails.application.configure do
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
+  config.i18n.default_locale = :en
+
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -4,7 +4,7 @@ module Features
       visit '/login'
       fill_in 'user_email', with: email
       fill_in 'user_password', with: password
-      click_button I18n.t('application.login_form.button')
+      click_button
     end
   end
 end


### PR DESCRIPTION
We were having problems with tests as much in local as in Travis because they weren't able to find the submit button on login, even though we were pretty sure of the button being there. At last, we found out that the page was printing in english and the test was looking for a spanish content of tag. So it wasn't able to find it.

In order of the test finding the submit button on login we set default.locale variable to english on  `config/environments/test.rb` to change the language in which the test looks for the button. 

It worked the other day in local, I have a witness (@sauloperez), but for some reason it's failing on Travis and local today. So, currently, I'm trying to figure out how to fix it for real.