### PR TITLE
Move spec from controller to view

### DIFF
--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -5,16 +5,6 @@ RSpec.describe OrganizationsController do
   let(:member) { Fabricate(:member, organization: organization) }
   let(:user) { member.user }
 
-  describe 'GET #show' do
-    it 'displays the organization page' do
-      get 'show', id: organization.id
-
-      expect(assigns(:organization)).to eq(organization)
-      expect(response.status).to eq(200)
-      expect(response.body).to include(organization.name)
-    end
-  end
-
   describe 'GET #index' do
     it 'populates and array of organizations' do
       get :index

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe OrganizationsController do
     end
   end
 
+  describe 'GET #show' do
+    it 'displays the organization page' do  
+      get 'show', id: organization.id
+
+      expect(assigns(:organization)).to eq(organization)
+      expect(response.status).to eq(200)
+    end
+  end
+
   describe 'POST #create' do
     it 'only superdamins are authorized create to new organizations' do
       login(member.user)

--- a/spec/views/organizations/show.html.erb_spec.rb
+++ b/spec/views/organizations/show.html.erb_spec.rb
@@ -57,5 +57,9 @@ RSpec.describe 'organizations/show' do
     it 'diplays the movements section' do
       expect(rendered).to match t('shared.movements.movements')
     end
+
+    it 'displays the organization page' do
+      expect(rendered).to match(organization.name)
+    end
   end
 end


### PR DESCRIPTION
We moved the 'displays the organization page' spec from controller specs to view specs and wrote it as a proper view spec.