### PR TITLE
WIP - Add users view specs

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -167,16 +167,7 @@ RSpec.describe UsersController do
         it "assigns the requested user to @user" do
           get "show", id: user.id
           expect(assigns(:user)).to eq(user)
-        end
-
-        it 'links to new_transfer_path for his individual offers' do
-          offer = Fabricate(:offer, user: user, organization: test_organization)
-
-          get "show", id: user.id
-          expect(response.body).to include(
-            "<a href=\"/transfers/new?destination_account_id=#{member.account.id}&amp;id=#{user.id}&amp;offer=#{offer.id}\">"
-          )
-        end
+        end        
       end
 
       context "with an admin logged user" do

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -1,0 +1,59 @@
+require "spec_helper"
+
+RSpec.describe 'users/show' do
+    let(:test_organization) { Fabricate(:organization) }
+    let(:member_admin) do
+        Fabricate(:member,
+         organization: test_organization,
+          manager: true)
+    end
+    let(:member) do
+    Fabricate(:member,
+              organization: test_organization,
+              manager: false)
+    end
+    let(:another_member) do
+    Fabricate(:member,
+              organization: test_organization,
+              manager: false)
+    end
+    let(:wrong_email_member) do
+    Fabricate(:member,
+              organization: test_organization,
+              manager: false)
+    end
+    let(:empty_email_member) do
+    Fabricate(:member,
+              organization: test_organization,
+              manager: false)
+    end
+
+    let(:offer) { Fabricate(:offer, user: member.user, organization: organization) }
+
+    let(:destination_account) { Fabricate(:account) }
+
+    let!(:user) { member.user }
+    let!(:another_user) { another_member.user }
+    let!(:admin_user) { member_admin.user }
+    let!(:wrong_user) { wrong_email_member.user }
+    let!(:empty_email_user) { empty_email_member.user }
+    
+    
+
+    before { login(user) }
+
+    it 'renders a link to new_transfer_path for their individual offers' do
+        assign :offer, offer
+        assign :destination_account, destination_account
+        render template: 'users/show'
+
+        expect(rendered).to have_link(
+            t('users.show.give_time'),
+            href: new_transfer_path(
+                id: offer.user.id
+                destination_account_id: destination_account.id
+                offer: offer.id
+            )
+        )
+    end      
+end

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -38,15 +38,23 @@ RSpec.describe 'users/show' do
     let!(:wrong_user) { wrong_email_member.user }
     let!(:empty_email_user) { empty_email_member.user }
 
+
+    let(:logged_user) { Fabricate(:user) }
+    before do
+        allow(view).to receive(:admin?).and_return(false)
+    end
+    
+
     it 'renders a link to new_transfer_path for their individual offers' do
         assign :offer, offer
         assign :destination_account, destination_account
+        allow(view).to receive(:current_user).and_return(logged_user)
         render template: 'users/show'
 
         expect(rendered).to have_link(
             t('users.show.give_time'),
             href: new_transfer_path(
-                id: offer.user.id,
+                id: user.id,
                 destination_account_id: destination_account.id,
                 offer: offer.id
             )

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -33,31 +33,39 @@ RSpec.describe 'users/show' do
     let(:destination_account) { Fabricate(:account) }
 
     let!(:user) { member.user }
-    let!(:another_user) { another_member.user }
     let!(:admin_user) { member_admin.user }
-    let!(:wrong_user) { wrong_email_member.user }
-    let!(:empty_email_user) { empty_email_member.user }
 
 
     let(:logged_user) { Fabricate(:user) }
+
     before do
         allow(view).to receive(:admin?).and_return(false)
     end
     
 
     it 'renders a link to new_transfer_path for their individual offers' do
-        assign :offer, offer
         assign :destination_account, destination_account
+        assign :user, user
+        assign :member, member
+        assign :offer, offer
+        assign :offers, member.user.offers.active
+        assign :movements, member.movements.page
+
         allow(view).to receive(:current_user).and_return(logged_user)
+        
         render template: 'users/show'
 
+        #expect(rendered).to have_selector("//a", text: "/transfers/new?destination_account_id=#{member.account.id}&amp;id=#{user.id}&amp;offer=#{offer.id}")
+        
+        byebug
         expect(rendered).to have_link(
-            t('users.show.give_time'),
+            nil,
             href: new_transfer_path(
                 id: user.id,
-                destination_account_id: destination_account.id,
+                destination_account_id: member.account.id,
                 offer: offer.id
             )
-        )
-    end      
+        ) 
+            
+     end
 end

--- a/spec/views/users/show.html.erb_spec.rb
+++ b/spec/views/users/show.html.erb_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe 'users/show' do
     let(:test_organization) { Fabricate(:organization) }
@@ -28,7 +28,7 @@ RSpec.describe 'users/show' do
               manager: false)
     end
 
-    let(:offer) { Fabricate(:offer, user: member.user, organization: organization) }
+    let(:offer) { Fabricate(:offer, user: member.user) }
 
     let(:destination_account) { Fabricate(:account) }
 
@@ -37,10 +37,6 @@ RSpec.describe 'users/show' do
     let!(:admin_user) { member_admin.user }
     let!(:wrong_user) { wrong_email_member.user }
     let!(:empty_email_user) { empty_email_member.user }
-    
-    
-
-    before { login(user) }
 
     it 'renders a link to new_transfer_path for their individual offers' do
         assign :offer, offer
@@ -50,8 +46,8 @@ RSpec.describe 'users/show' do
         expect(rendered).to have_link(
             t('users.show.give_time'),
             href: new_transfer_path(
-                id: offer.user.id
-                destination_account_id: destination_account.id
+                id: offer.user.id,
+                destination_account_id: destination_account.id,
                 offer: offer.id
             )
         )


### PR DESCRIPTION
I'm trying to move this users controller spec to view specs:
https://github.com/coopdevs/timeoverflow/blob/5a1e4cd8fb87badf8e83d9347e165a5b164ddbd0/spec/controllers/users_controller_spec.rb#L172-L179

But I got stuck because when I try to render the template, it doesn't find the active offers, so doesn't print the link I'm trying to test:
https://github.com/coopdevs/timeoverflow/blob/5a1e4cd8fb87badf8e83d9347e165a5b164ddbd0/app/views/users/show.html.erb#L90-L103

So, I've been looking on how to access the active offers and I'm only capable by calling to `member.user.offers.active` since the offers are an attribute of user, and not member. As you can see above, the `for each` is calling to `member.offers.active`. I know that must be correct because it actually works on the app, but cannot see how to do the relation between `member` and `offers` without calling `user`.

Any ideas? 
