### PR TITLE
Allow requests from staging

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,6 @@ module Timeoverflow
 
     # Guard against DNS rebinding attacks by permitting hosts
     config.hosts << /timeoverflow\.(local|org)/
+    config.hosts << "staging.timeoverflow.org"
   end
 end


### PR DESCRIPTION
This fixes what I see right after a deployment from develop

![Screenshot from 2021-01-05 10-08-38](https://user-images.githubusercontent.com/762088/103627513-07102f80-4f3e-11eb-9d8c-9d8a970bb8b9.png)

Note I had to manually run `sudo systemctl restart timeoverflow` as a `reload` didn't seem to be enough to pick up the change.