### PR TITLE
Allow requests from production host

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,8 @@ module Timeoverflow
     config.active_record.schema_format = :sql
 
     # Guard against DNS rebinding attacks by permitting hosts
-    config.hosts << /timeoverflow\.(local|org)/
-    config.hosts << "staging.timeoverflow.org"
+    config.hosts << 'timeoverflow.local'
+    config.hosts << 'staging.timeoverflow.org'
+    config.hosts << 'www.timeoverflow.org'
   end
 end


### PR DESCRIPTION
We missed the mess we have at DNS level with the www domain. We need this to make it work in production. IMO it's much more explicit add a host per line instead of the regex.