### PR TITLE
Allow non-www host name

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,6 @@ module Timeoverflow
     config.hosts << 'timeoverflow.local'
     config.hosts << 'staging.timeoverflow.org'
     config.hosts << 'www.timeoverflow.org'
+    config.hosts << 'timeoverflow.org'
   end
 end


### PR DESCRIPTION
As far as I know our DNS provider redirects itself timeoverflow.org to www.timeoverflow.org instead of our Nginx, as we are used to, but we're seeing people getting ERR_CONNECTION_REFUSED, with mobile data only, they say. We hope this may fix it but we're totally blind here.