### PR TITLE
add empty config/storage.yml to avoid app crashes on boot (eager_load)

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,1 @@
+# Empty config/storage.yml to avoid app crashes on boot


### PR DESCRIPTION
Fixes https://github.com/coopdevs/timeoverflow/pull/589#issuecomment-757102480 @sseerrggii 

We are not using ActiveStorage yet, but last Rails version seems to require this file to exists (only noticeable in "eager load" environments).