### PR TITLE
admin: fix post creation with tags 

### DIFF
--- a/app/admin/post.rb
+++ b/app/admin/post.rb
@@ -2,6 +2,7 @@ ActiveAdmin.register Post do
   index do
     id_column
     column :class
+    column :is_group
     column :title
     column :created_at do |post|
       l post.created_at.to_date, format: :long
@@ -19,10 +20,11 @@ ActiveAdmin.register Post do
       f.input :type, as: :radio, collection: %w[Offer Inquiry]
       f.input :title
       f.input :organization
-      f.input :user, hint: "* should be member of the selected organization"
+      f.input :user, hint: "Should be member of the selected organization"
       f.input :category
       f.input :description
-      f.input :tag_list
+      f.input :tag_list, hint: "Accepts comma separated values"
+      f.input :is_group
       f.input :active
     end
     f.actions
@@ -36,6 +38,7 @@ ActiveAdmin.register Post do
   filter :organization
   filter :user
   filter :category
+  filter :is_group
   filter :active
   filter :created_at
 end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -29,12 +29,14 @@ ActiveAdmin.register User do
   filter :organizations
   filter :email
   filter :username
+  filter :phone
 
   form do |f|
     f.semantic_errors *f.object.errors.keys
     f.inputs do
       f.input :username
       f.input :email
+      f.input :phone
       f.input :gender, as: :select, collection: User::GENDERS
       f.input :identity_document
     end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -13,8 +13,10 @@ module Taggable
     tags && tags.join(", ")
   end
 
-  def tag_list=(tag_list)
-    self.tags = tag_list.reject(&:empty?)
+  def tag_list=(new_tags)
+    new_tags = new_tags.split(",").map(&:strip) if new_tags.is_a?(String)
+
+    self.tags = new_tags.reject(&:empty?)
   end
 
   module ClassMethods

--- a/spec/fabricators/member_fabricator.rb
+++ b/spec/fabricators/member_fabricator.rb
@@ -1,8 +1,6 @@
 Fabricator(:member) do
-
   user { Fabricate(:user) }
   organization { Fabricate(:organization) }
   manager false
   active true
-
 end

--- a/spec/fabricators/post_fabricator.rb
+++ b/spec/fabricators/post_fabricator.rb
@@ -1,15 +1,12 @@
 Fabricator(:post) do
-
   title { Faker::Lorem.sentence }
   user { Fabricate(:user) }
   description { Faker::Lorem.paragraph }
   category { Fabricate(:category) }
   active { true }
-
 end
 
 Fabricator(:inquiry) do
-
   type "Inquiry"
 
   title { Faker::Lorem.sentence }
@@ -21,7 +18,6 @@ Fabricator(:inquiry) do
 end
 
 Fabricator(:offer) do
-
   type "Offer"
 
   title { Faker::Lorem.sentence }
@@ -29,5 +25,4 @@ Fabricator(:offer) do
   description { Faker::Lorem.paragraph }
   category { Fabricate(:category) }
   active { true }
-
 end

--- a/spec/models/taggable_spec.rb
+++ b/spec/models/taggable_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe Taggable do
   let(:organization) { Fabricate(:organization) }
-
+  let(:tags) { %w(foo bar baz) }
+  let(:more_tags) { %w(foo baz qux) }
   let!(:offer) do
     Fabricate(
       :offer,
@@ -17,9 +18,6 @@ RSpec.describe Taggable do
   end
 
   context "class methods and scopes" do
-    let(:tags) { %w(foo bar baz) }
-    let(:more_tags) { %w(foo baz qux) }
-
     it "tagged_with" do
       expect(Offer.tagged_with("bar")).to eq [offer]
     end
@@ -33,18 +31,28 @@ RSpec.describe Taggable do
       expect(Offer.find_like_tag("Foo")).to eq ["foo"]
       expect(Offer.find_like_tag("none")).to eq []
     end
+
+    describe '.alphabetical_grouped_tags' do
+      let(:tags) { %w(foo bar baz Boo) }
+      let(:more_tags) { %w(foo baz qux) }
+
+      it 'sorts them by alphabetical order case insensitive' do
+        expect(Offer.alphabetical_grouped_tags).to eq({
+          'B' => [['bar', 1], ['baz', 2], ['Boo', 1]],
+          'F' => [['foo', 2]],
+          'Q' => [['qux', 1]]
+        })
+      end
+    end
   end
 
-  describe '.alphabetical_grouped_tags' do
-    let(:tags) { %w(foo bar baz Boo) }
-    let(:more_tags) { %w(foo baz qux) }
+  it "#tag_list= writter accepts string and array" do
+    offer = Offer.new
 
-    it 'sorts them by alphabetical order case insensitive' do
-      expect(Offer.alphabetical_grouped_tags).to eq({
-        'B' => [['bar', 1], ['baz', 2], ['Boo', 1]],
-        'F' => [['foo', 2]],
-        'Q' => [['qux', 1]]
-      })
-    end
+    offer.tag_list = ["a", "b"]
+    expect(offer.tag_list).to eq "a, b"
+
+    offer.tag_list = "c, d"
+    expect(offer.tag_list).to eq "c, d"
   end
 end


### PR DESCRIPTION
In #617 I didn't realize that trying to create a post with tags (in the admin section) didn't work. Even before that PR (in master), didn't work either. So basically, now we'll able to send tags as string (comma separated) and create/update "complete" posts from the admin section 👌🏼 . I also added of couple missing filters :)