### PR TITLE
Time exchanges can now be made between organisations

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -6,7 +6,7 @@ class OffersController < PostsController
   def show
     super
 
-    member = @offer.user.members.find_by(organization: current_organization)
+    member = @offer.user.members.find_by(organization: @offer.organization)
     @destination_account = member.account if member
   end
 end

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -5,16 +5,12 @@ class TransfersController < ApplicationController
     @source = find_source
     @account = Account.find(transfer_params[:destination])
 
-    transfer = Transfer.new(
-      transfer_params.merge(source: @source, destination: @account)
-    )
+    create_persisters
 
-    persister = ::Persister::TransferPersister.new(transfer)
-
-    if persister.save
+    if persisters_saved?
       redirect_to redirect_target
     else
-      redirect_back fallback_location: redirect_target, alert: transfer.errors.full_messages.to_sentence
+      redirect_back fallback_location: redirect_target, alert: @transfer.errors.full_messages.to_sentence
     end
   end
 
@@ -23,7 +19,8 @@ class TransfersController < ApplicationController
       current_organization,
       current_user,
       params[:offer],
-      params[:destination_account_id]
+      params[:destination_account_id],
+      params[:organization_id] || current_organization.id
     )
 
     render(
@@ -57,12 +54,37 @@ class TransfersController < ApplicationController
     end
   end
 
+  def create_persisters
+    source_organization = @source.organization.account
+    destination_organization = @account.organization.account
+
+    if source_organization == destination_organization
+      @persister = transfer_persister_between(@source, @account)
+    else
+      @pers_src_org = transfer_persister_between(@source, source_organization)
+      @pers_between_orgs = transfer_persister_between(source_organization, destination_organization)
+      @pers_org_acc = transfer_persister_between(destination_organization, @account)
+    end
+  end
+
+  def transfer_persister_between(source, destination)
+    @transfer = Transfer.new(
+      transfer_params.merge(source: source, destination: destination)
+    )
+
+    ::Persister::TransferPersister.new(@transfer)
+  end
+
+  def persisters_saved?
+    @persister&.save || @pers_src_org&.save && @pers_between_orgs&.save && @pers_org_acc&.save
+  end
+
   def redirect_target
     case accountable = @account.accountable
     when Organization
       accountable
     when Member
-      accountable.user
+      accountable.organization == current_organization ? accountable.user : @source.accountable.user
     else
       raise ArgumentError
     end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -65,6 +65,10 @@ class Organization < ApplicationRecord
     reg_number_seq
   end
 
+  def global_balance
+    Account.where(organization_id: id).sum(:balance)
+  end
+
   def ensure_url
     return if web.blank? || URI.parse(web).is_a?(URI::HTTP)
   rescue

--- a/app/models/transfer_factory.rb
+++ b/app/models/transfer_factory.rb
@@ -1,16 +1,22 @@
 class TransferFactory
-  def initialize(current_organization, current_user, offer_id, destination_account_id)
+  def initialize(current_organization, current_user, offer_id, destination_account_id,
+                 destination_organization_id)
     @current_organization = current_organization
     @current_user = current_user
     @offer_id = offer_id
     @destination_account_id = destination_account_id
+    @destination_organization_id = destination_organization_id.to_i
+  end
+
+  def destination_organization
+    Organization.find(@destination_organization_id)
   end
 
   # Returns the offer that is the subject of the transfer
   #
   # @return [Maybe<Offer>]
   def offer
-    current_organization.offers.find_by_id(offer_id)
+    destination_organization.offers.find_by_id(offer_id)
   end
 
   # Returns a new instance of Transfer with the data provided
@@ -73,7 +79,7 @@ class TransferFactory
   #
   # @return [Account]
   def destination_account
-    @destination_account ||= current_organization
+    @destination_account ||= destination_organization
       .all_accounts
       .find(destination_account_id)
   end

--- a/app/views/offers/show.html.erb
+++ b/app/views/offers/show.html.erb
@@ -11,5 +11,16 @@
       <% end %>
     <% end %>
   </p>
+<% else %>
+  <p class="actions text-right">
+    <% if current_user and @offer.user != current_user %>
+      <%= link_to new_transfer_path(id: @offer.user.id, offer: @offer.id, destination_account_id: @destination_account.id, 
+                                    organization_id: @offer.organization.id),
+                  class: "btn btn-success" do %>
+        <%= glyph :time %>
+        <%= t ".give_time_for" %>
+      <% end %>
+    <% end %>
+  </p>
 <% end %>
 <%= render "shared/post", post: @offer %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -78,6 +78,11 @@
             <%= t 'global.balance' %>
           </strong>
           <%= seconds_to_hm(@organization.account.try(:balance)) %>
+          <br/>
+          <strong>
+            <%= t 'global.global_balance' %>
+          </strong>
+          <%= seconds_to_hm(@organization.try(:global_balance)) %>
         </p>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -281,6 +281,7 @@ en:
     filter: Filter
     from: From
     give_time: Time transfer
+    global_balance: Global balance
     home: Home
     information: Information
     locales_header: change language

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -3,6 +3,8 @@ RSpec.describe TransfersController do
   let (:member_admin) { Fabricate(:member, organization: test_organization, manager: true) }
   let (:member_giver) { Fabricate(:member, organization: test_organization) }
   let (:member_taker) { Fabricate(:member, organization: test_organization) }
+  let (:second_organization) { Fabricate(:organization) }
+  let (:second_member_taker) { Fabricate(:member, organization: second_organization) }
 
   describe '#new' do
     let(:user) { member_giver.user }
@@ -48,6 +50,28 @@ RSpec.describe TransfersController do
         it 'builds a transfer with the offer as post' do
           get :new, params: params.merge(offer: offer.id)
           expect(response.body).to include("<input class=\"form-control hidden form-control\" type=\"hidden\" value=\"#{offer.id}\" name=\"transfer[post_id]\" id=\"transfer_post_id\" />")
+        end
+      end
+
+      context 'when the offer is specified and belongs to another organization' do
+        let(:other_offer) { Fabricate(:offer, organization: second_organization) }
+
+        it 'finds the transfer offer' do
+          dest_acc_id = second_member_taker.user.accounts.first.id
+          get :new, params: params.merge(offer: other_offer.id,
+                                         organization_id: other_offer.organization.id,
+                                         destination_account_id: dest_acc_id)
+
+          expect(response.body).to include("<h3>#{other_offer}</h3>")
+        end
+
+        it 'builds a transfer with the offer as post' do
+          dest_acc_id = second_member_taker.user.accounts.first.id
+          get :new, params: params.merge(offer: other_offer.id,
+                                         organization_id: other_offer.organization.id,
+                                         destination_account_id: dest_acc_id)
+
+          expect(response.body).to include("<input class=\"form-control hidden form-control\" type=\"hidden\" value=\"#{other_offer.id}\" name=\"transfer[post_id]\" id=\"transfer_post_id\" />")
         end
       end
 
@@ -142,26 +166,68 @@ RSpec.describe TransfersController do
           } }
         end
 
+        subject(:create_between_orgs) do
+          post 'create', params: { transfer: {
+            source: member_giver.account.id,
+            destination: second_member_taker.account.id,
+            amount: 5
+          } }
+        end
+
         let(:user) { member_admin.user }
+        context 'the transfer is within the same organisation' do
+          it 'creates a new Transfer' do
+            expect { post_create }.to change(Transfer, :count).by 1
+          end
 
-        it 'creates a new Transfer' do
-          expect { post_create }.to change(Transfer, :count).by 1
+          it 'creates two Movements' do
+            expect { post_create }.to change { Movement.count }.by 2
+          end
+
+          it 'updates the balance of both accounts' do
+            expect do
+              post_create
+              member_giver.reload
+            end.to change { member_giver.account.balance.to_i }.by -5
+
+            expect do
+              post_create
+              member_taker.reload
+            end.to change { member_taker.account.balance.to_i }.by 5
+          end
         end
 
-        it 'creates two Movements' do
-          expect { post_create }.to change { Movement.count }.by 2
-        end
+        context 'the transfer is between members of different organisations' do
+          it 'creates three news Transfers' do
+            expect { create_between_orgs }.to change(Transfer, :count).by 3
+          end
 
-        it 'updates the balance of both accounts' do
-          expect do
-            post_create
-            member_giver.reload
-          end.to change { member_giver.account.balance.to_i }.by -5
+          it 'creates six Movements' do
+            expect { create_between_orgs }.to change { Movement.count }.by 6
+          end
 
-          expect do
-            post_create
-            member_taker.reload
-          end.to change { member_taker.account.balance.to_i }.by 5
+          it 'updates the balance of both accounts' do
+            expect do
+              create_between_orgs
+              member_giver.reload
+            end.to change { member_giver.account.balance.to_i }.by -5
+
+            expect do
+              create_between_orgs
+              second_member_taker.reload
+            end.to change { second_member_taker.account.balance.to_i }.by 5
+          end
+
+          it 'updates the global balance of both organizations' do
+            create_between_orgs
+
+            expect(test_organization.global_balance).to equal -5
+            expect(second_organization.global_balance).to equal 5
+          end
+
+          it 'redirects to source user' do
+            expect(create_between_orgs).to redirect_to(member_giver.user)
+          end
         end
       end
 
@@ -173,30 +239,71 @@ RSpec.describe TransfersController do
           } }
         end
 
+        subject(:create_between_orgs) do
+          post 'create', params: { transfer: {
+            destination: second_member_taker.account.id,
+            amount: 5
+          } }
+        end
+
         let(:user) { member_giver.user }
+        context 'the transfer is within the same organisation' do
+          it 'creates a new Transfer' do
+            expect { post_create }.to change(Transfer, :count).by 1
+          end
 
-        it 'creates a new Transfer' do
-          expect { post_create }.to change(Transfer, :count).by 1
+          it 'creates two Movements' do
+            expect { post_create }.to change { Movement.count }.by 2
+          end
+
+          it 'updates the balance of both accounts' do
+            expect do
+              post_create
+              member_giver.reload
+            end.to change { member_giver.account.balance.to_i }.by -5
+
+            expect do
+              post_create
+              member_taker.reload
+            end.to change { member_taker.account.balance.to_i }.by 5
+          end
+
+          it 'redirects to destination' do
+            expect(post_create).to redirect_to(member_taker.user)
+          end
         end
 
-        it 'creates two Movements' do
-          expect { post_create }.to change { Movement.count }.by 2
-        end
+        context 'the transfer is to a member of another organizations' do
+          it 'creates three news Transfers' do
+            expect { create_between_orgs }.to change(Transfer, :count).by 3
+          end
 
-        it 'updates the balance of both accounts' do
-          expect do
-            post_create
-            member_giver.reload
-          end.to change { member_giver.account.balance.to_i }.by -5
+          it 'creates six Movements' do
+            expect { create_between_orgs }.to change { Movement.count }.by 6
+          end
 
-          expect do
-            post_create
-            member_taker.reload
-          end.to change { member_taker.account.balance.to_i }.by 5
-        end
+          it 'updates the balance of both accounts' do
+            expect do
+              create_between_orgs
+              member_giver.reload
+            end.to change { member_giver.account.balance.to_i }.by -5
 
-        it 'redirects to destination' do
-          expect(post_create).to redirect_to(member_taker.user)
+            expect do
+              create_between_orgs
+              second_member_taker.reload
+            end.to change { second_member_taker.account.balance.to_i }.by 5
+          end
+
+          it 'updates the global balance of both organizations' do
+            create_between_orgs
+
+            expect(test_organization.global_balance).to equal -5
+            expect(second_organization.global_balance).to equal 5
+          end
+
+          it 'redirects to source' do
+            expect(create_between_orgs).to redirect_to(member_giver.user)
+          end
         end
       end
     end
@@ -204,17 +311,31 @@ RSpec.describe TransfersController do
     context 'with invalid params' do
       let(:user) { member_giver.user }
       let(:referer) { "/transfers/new?destination_account_id=#{member_taker.account.id}" }
+      let(:second_referer) { "/transfers/new?destination_account_id=#{member_taker.account.id}&organization_id=#{second_organization.id}" }
 
       before do
         request.env["HTTP_REFERER"] = referer
       end
 
-      it 'does not create any Transfer and redirects to back if the amount is 0' do
-        expect {
-          post(:create, params: { transfer: { amount: 0, destination: member_taker.account.id } })
-        }.not_to change(Transfer, :count)
+      context 'the transfer is to a member of the same organization' do
+        it 'does not create any Transfer and redirects to back if the amount is 0' do
+          expect {
+            post(:create, params: { transfer: { amount: 0, destination: member_taker.account.id } })
+          }.not_to change(Transfer, :count)
 
-        expect(response).to redirect_to(referer)
+          expect(response).to redirect_to(referer)
+        end
+      end
+
+      context 'the transfer is to a member of another organization' do
+        it 'does not create any Transfer and redirects to back if the amount is 0' do
+          request.env["HTTP_REFERER"] = second_referer
+          expect {
+            post(:create, params: { transfer: { amount: 0, destination: second_member_taker.account.id } })
+          }.not_to change(Transfer, :count)
+
+          expect(response).to redirect_to(second_referer)
+        end
       end
     end
   end

--- a/spec/models/transfer_factory_spec.rb
+++ b/spec/models/transfer_factory_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe TransferFactory do
       organization,
       current_user,
       offer_id,
-      destination_account_id
+      destination_account_id,
+      destination_organization_id
     )
   end
 
@@ -12,6 +13,7 @@ RSpec.describe TransferFactory do
   let(:current_user) { Fabricate(:user) }
   let(:organization_offer) { Fabricate(:offer, organization: organization) }
   let(:destination_account_id) { nil }
+  let(:destination_organization_id) { organization.id }
 
   describe '#offer' do
     subject { transfer_factory.offer }
@@ -32,6 +34,7 @@ RSpec.describe TransferFactory do
 
     let(:offer_id) { organization_offer.id }
     let(:destination_account_id) { destination_account.id }
+    let(:destination_organization_id) { organization.id }
 
     context 'when the destination account belongs to an organization' do
       let(:organization) { Fabricate(:organization) }
@@ -77,6 +80,7 @@ RSpec.describe TransferFactory do
     subject { transfer_factory.transfer_sources }
 
     let(:offer_id) { organization_offer.id }
+    let(:destination_organization_id) { organization.id }
 
     let!(:active_member) do
       Fabricate(:member, organization: organization, active: true)

--- a/spec/views/offers/show.html.erb_spec.rb
+++ b/spec/views/offers/show.html.erb_spec.rb
@@ -65,16 +65,18 @@ RSpec.describe 'offers/show' do
         allow(view).to receive(:current_organization) { another_organization }
       end
 
-      it 'doesn\'t render a link to the transfer page' do
+      it 'render a link to the transfer page with the id of the destination organisation' do
         assign :offer, offer
+        assign :destination_account, destination_account
         render template: 'offers/show'
 
-        expect(rendered).to_not have_link(
+        expect(rendered).to have_link(
           t('offers.show.give_time_for'),
           href: new_transfer_path(
             id: offer.user.id,
             offer: offer.id,
-            destination_account_id: destination_account.id
+            destination_account_id: destination_account.id,
+            organization_id: organization.id
           )
         )
       end
@@ -89,6 +91,7 @@ RSpec.describe 'offers/show' do
 
       it 'displays the offer\'s organization' do
         assign :offer, offer
+        assign :destination_account, destination_account
         render template: 'offers/show'
 
         expect(rendered).to include(


### PR DESCRIPTION
The feature is working exactly as shown in [this drawing](https://github.com/coopdevs/timeoverflow/issues/638#issuecomment-841066253). Here you can see it working in the following video and the full trace it would do:

https://user-images.githubusercontent.com/70280187/118401127-bedbe900-b664-11eb-8a57-abbe6b474654.mp4

If the source account is the organisation the first trace between first member and organisation would not be there but the rest is the same. When a member makes a donation it is the same, except that they cannot choose the source (as they do with current transfers).

For the implementation I have adapted the current transfers and therefore also had to change some tests (minor changes and specification of a new context).

closes #638.