### PR TITLE
A detailed CSV of the organization

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -24,13 +24,17 @@ class ReportsController < ApplicationController
     report_responder('Transfer', current_organization, @transfers)
   end
 
+  def download_csv_detailed
+    download_report("Csv::Detailed", current_organization)
+  end
+
   def download_all
     filename = "#{current_organization.name.parameterize}_#{Date.today}.zip"
     temp_file = Tempfile.new(filename)
 
     begin
       Zip::File.open(temp_file.path, Zip::File::CREATE) do |zipfile|
-        %w(Member Transfer Inquiry Offer).each do |report_class|
+        %w(Member Transfer Inquiry Offer Detailed).each do |report_class|
           add_csv_to_zip(report_class, zipfile)
         end
       end
@@ -85,6 +89,8 @@ class ReportsController < ApplicationController
 
     report = if report_class.in? %w(Inquiry Offer)
       get_report("Csv::Post", current_organization, collection, report_class.constantize)
+    elsif report_class == "Detailed"
+      get_report("Csv::#{report_class}", current_organization)
     else
       get_report("Csv::#{report_class}", current_organization, collection)
     end

--- a/app/decorators/report/detailed_decorator.rb
+++ b/app/decorators/report/detailed_decorator.rb
@@ -1,0 +1,135 @@
+class Report::DetailedDecorator
+  include TransfersHelper
+
+  def initialize(org)
+    @org = org
+  end
+
+  def name(extension)
+    "#{@org.name.parameterize}_"\
+    "#{Date.today}."\
+    "#{I18n.t('global.detailed')}_"\
+    ".#{extension}"
+  end
+
+  def headers
+    ["#{@org.name} #{I18n.t('global.detailed')}"]
+  end
+
+  def rows
+    make_table(Organization, organization_header, organization_row) +
+      make_table(User, member_headers, member_rows) +
+      make_table(Account, account_headers, account_rows) +
+      make_table(Post, post_headers, post_rows) +
+      make_table(Transfer, transfer_headers, transfer_rows)
+  end
+
+  private
+
+  def organization_header
+    make_headers(Organization, %w[reg_number_seq])
+  end
+
+  def organization_row
+    make_rows(Organization, %w[reg_number_seq], [@org])
+  end
+
+  def member_headers
+    excluded_users = %w[id encrypted_password reset_password_token reset_password_token
+                        reset_password_sent_at current_sign_in_ip last_sign_in_ip confirmation_token
+                        remember_created_at unconfirmed_email unlock_token locked_at notifications
+                        push_notifications created_at updated_at active]
+    excluded_members = %w[user_id organization_id member_uid]
+
+    make_headers(Member, excluded_members) +
+      make_headers(User, excluded_users)
+  end
+
+  def member_rows
+    excluded_users = %w[id encrypted_password reset_password_token reset_password_token
+                        reset_password_sent_at current_sign_in_ip last_sign_in_ip confirmation_token
+                        remember_created_at unconfirmed_email unlock_token locked_at notifications
+                        push_notifications created_at updated_at active]
+    user_rows = make_rows(User, excluded_users, @org.users)
+    @org.members.each_with_index.map do |member, ix|
+      [member.member_uid,
+       member.manager,
+       member.created_at,
+       member.updated_at,
+       member.entry_date,
+       member.active,
+       member.tag_list.to_s] + user_rows[ix]
+    end
+  end
+
+  def account_headers
+    make_headers(Account, %w[max_allowed_balance min_allowed_balance updated_at organization_id])
+  end
+
+  def account_rows
+    make_rows(Account, %w[max_allowed_balance min_allowed_balance updated_at organization_id],
+              Account.where(organization: @org))
+  end
+
+  def post_headers
+    make_headers(Post, %w[tsv])
+  end
+
+  def post_rows
+    make_rows(Post, %w[tsv], @org.posts.map)
+  end
+
+  def transfer_headers
+    headers = []
+    excluded = %w[operator_id updated_at created_at]
+    Transfer.columns.each { |col| headers << col.name if !excluded.include?(col.name) }
+    headers + [
+      I18n.t('statistics.all_transfers.from'),
+      "#{I18n.t('statistics.all_transfers.from')}_#{I18n.t('statistics.all_transfers.type')}",
+      I18n.t('statistics.all_transfers.to'),
+      "#{I18n.t('statistics.all_transfers.to')}_#{I18n.t('statistics.all_transfers.type')}",
+      I18n.t('statistics.all_transfers.quantity'),
+      I18n.t('statistics.all_transfers.date')
+    ]
+  end
+
+  def transfer_rows
+    @org.all_transfers_with_accounts.map do |transfer|
+      [transfer.id,
+       transfer.post_id,
+       transfer.reason,
+       accounts_from_movements_id(transfer),
+       transfer.movements.first.amount.abs,
+       transfer.created_at.to_s].flatten
+    end
+  end
+
+  def make_table(table, header, rows)
+    [[table.model_name.human]] + [header] + rows
+  end
+
+  def make_headers(table, excluded)
+    table.columns.map { |col| table.human_attribute_name(col.name) if !excluded.include?(col.name) }.
+      grep(String)
+  end
+
+  def make_rows(table, excluded, collection)
+    collection.map do |single|
+      table.columns.map do |col|
+        get_value_column(col.name, single, excluded)
+      end.grep(String)
+    end
+  end
+
+  def get_value_column(col_name, single, excluded)
+    if col_name == 'tags'
+      single.tag_list.to_s
+    elsif col_name == 'accountable_id' && single.accountable_type == 'Member'
+      single.accountable.member_uid.to_s
+    elsif col_name == 'category_id'
+      single.category.to_s
+    elsif !excluded.include?(col_name)
+      single[col_name].to_s.truncate(60)
+    end
+  end
+end

--- a/app/decorators/report/detailed_decorator.rb
+++ b/app/decorators/report/detailed_decorator.rb
@@ -7,9 +7,9 @@ class Report::DetailedDecorator
 
   def name(extension)
     "#{@org.name.parameterize}_"\
-    "#{Date.today}."\
     "#{I18n.t('global.detailed')}_"\
-    ".#{extension}"
+    "#{Date.today}."\
+    "#{extension}"
   end
 
   def headers
@@ -76,7 +76,7 @@ class Report::DetailedDecorator
   end
 
   def post_rows
-    make_rows(Post, %w[tsv], @org.posts.map)
+    make_rows(Post, %w[tsv], @org.posts)
   end
 
   def transfer_headers

--- a/app/decorators/report/member_decorator.rb
+++ b/app/decorators/report/member_decorator.rb
@@ -19,9 +19,7 @@ class Report::MemberDecorator
       User.human_attribute_name(:phone),
       User.human_attribute_name(:alt_phone),
       User.human_attribute_name(:created_at),
-      User.human_attribute_name(:last_sign_in_at),
-      User.human_attribute_name(:locale),
-      Account.human_attribute_name(:balance)
+      User.human_attribute_name(:last_sign_in_at)
     ]
   end
 
@@ -34,9 +32,7 @@ class Report::MemberDecorator
         member.user.phone,
         member.user.alt_phone,
         member.user.created_at.to_s,
-        member.user.last_sign_in_at.to_s,
-        member.user.locale,
-        member.account_balance.to_s
+        member.user.last_sign_in_at.to_s
       ]
     end
   end

--- a/app/decorators/report/post_decorator.rb
+++ b/app/decorators/report/post_decorator.rb
@@ -14,7 +14,6 @@ class Report::PostDecorator
 
   def headers
     [
-      "",
       @type.model_name.human,
       Post.human_attribute_name(:tag_list),
       User.model_name.human,
@@ -30,7 +29,6 @@ class Report::PostDecorator
 
       posts.each do |post|
         grouped_rows << [
-          post.id,
           post.title,
           post.tag_list.to_s,
           "#{post.user} (#{post.member_uid})",

--- a/app/helpers/transfers_helper.rb
+++ b/app/helpers/transfers_helper.rb
@@ -22,4 +22,20 @@ module TransfersHelper
       end
     end
   end
+
+  def accounts_from_movements_id(transfer)
+    transfer.movements.sort_by(&:amount).map do |movement|
+      account = movement.account
+
+      if account.accountable.blank?
+        I18n.t('users.show.deleted_user')
+      elsif account.accountable_type == 'Organization'
+        [account.accountable.id, account.accountable_type]
+      elsif account.accountable.active
+        [account.accountable.member_uid, account.accountable_type]
+      else
+        I18n.t('users.show.inactive_user')
+      end
+    end
+  end
 end

--- a/app/services/report/csv/detailed.rb
+++ b/app/services/report/csv/detailed.rb
@@ -1,0 +1,9 @@
+module Report
+  module Csv
+    class Detailed < Base
+      def initialize(org)
+        self.decorator = Report::DetailedDecorator.new(org)
+      end
+    end
+  end
+end

--- a/app/views/application/menus/_organization_reports_menu.html.erb
+++ b/app/views/application/menus/_organization_reports_menu.html.erb
@@ -31,6 +31,12 @@
     </li>
     <li class="divider" role="presentation"></li>
     <li>
+      <%= link_to download_csv_detailed_report_path do %>
+        <%= glyph :download %>
+        <%= "CSV #{t 'global.detailed' }" %>
+      <% end %>
+    </li>
+    <li>
       <%= link_to download_all_report_path do %>
         <%= glyph :download %>
         <%= t 'reports.download_all' %>

--- a/app/views/reports/post_list.html.erb
+++ b/app/views/reports/post_list.html.erb
@@ -2,7 +2,6 @@
   <table class="table table-condensed table-bordered">
     <thead>
       <tr>
-        <th></th>
         <th><%= @post_type.model_name.human %></th>
         <th><%= Post.human_attribute_name :tag_list %></th>
         <th><%= User.model_name.human %></th>
@@ -16,7 +15,6 @@
         </tr>
         <% ps.each do |post| %>
           <tr>
-            <td><%= post.id %></td>
             <td><strong><%= post.title %></strong></td>
             <td><%= post.tag_list %></td>
             <td><%= "#{post.user} (#{post.member_uid})" %></td>

--- a/app/views/reports/user_list.html.erb
+++ b/app/views/reports/user_list.html.erb
@@ -9,8 +9,6 @@
         <th><%= User.human_attribute_name :alt_phone %></th>
         <th><%= User.human_attribute_name :created_at %></th>
         <th><%= User.human_attribute_name :last_sign_in_at %></th>
-        <th><%= User.human_attribute_name :locale %></th>
-        <th><%= Account.human_attribute_name :balance %></th>
       </tr>
     </thead>
     <tbody>
@@ -23,8 +21,6 @@
           <td><%= member.user.alt_phone %></td>
           <td><%= l(member.user.created_at, format: :long) %></td>
           <td><%= l(member.user.last_sign_in_at, format: :long) if member.user.last_sign_in_at.present? %></td>
-          <td><%= member.user.locale %></td>
-          <td><%= member.account_balance %></td>
         </tr>
       <% end %>
     </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,6 +276,7 @@ en:
     date: Data
     delete: Delete
     demote: Demote to normal user
+    detailed: detailed
     edit: Update
     enter_to_timebank: Enter to timebank
     filter: Filter
@@ -450,6 +451,7 @@ en:
       reason: Reason
       to: To
       transfers: All transfers
+      type: type
     demographics:
       by_ages: By ages
       by_gender: By gender

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
       get "offer_list" => :post_list, type: "offer"
       get "inquiry_list" => :post_list, type: "inquiry"
       get "transfer_list"
+      get "download_csv_detailed"
       get "download_all"
     end
   end

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -90,6 +90,16 @@ RSpec.describe ReportsController do
       end
     end
 
+    describe 'GET #download_csv_detailed' do
+      it 'downloads a CSV' do
+        get :download_csv_detailed
+        report = Report::Csv::Detailed.new(test_organization)
+
+        expect(response.body).to eq(report.run)
+        expect(response.media_type).to eq("text/csv")
+      end
+    end
+
     describe 'GET #download_all' do
       it 'downloads a zip' do
         get :download_all
@@ -99,6 +109,7 @@ RSpec.describe ReportsController do
         expect(response.body).to include('Offers')
         expect(response.body).to include('Members')
         expect(response.body).to include('Transfers')
+        expect(response.body).to include('Detaileds')
       end
 
       it 'redirects to download_all_report_path (retry) if zip is not ready' do

--- a/spec/decorators/report/detailed_decorator_spec.rb
+++ b/spec/decorators/report/detailed_decorator_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe Report::DetailedDecorator do
+  let (:member) { Fabricate(:member) }
+  let (:org) { member.organization }
+  let (:decorator) do
+    Report::DetailedDecorator.new(org)
+  end
+  let (:category) { Fabricate(:category) }
+  let (:transfer) { Fabricate(:transfer, source: org.account, destination: member.account) }
+  let! (:offer) do
+    Fabricate(:offer,
+              user: member.user,
+              organization: org,
+              category: category)
+  end
+
+  it "#name" do
+    expect(decorator.name(:csv)).to eq(
+      "#{org.name.parameterize}_"\
+      "#{I18n.t('global.detailed')}_"\
+      "#{Date.today}."\
+      "csv"
+    )
+  end
+
+  it "#headers" do
+    expect(decorator.headers).to eq(["#{org.name} #{I18n.t('global.detailed')}"])
+  end
+
+  it "#rows" do
+    expect(decorator.rows.to_s).to include(org.name)
+    expect(decorator.rows.to_s).to include(transfer.reason.to_s)
+    expect(decorator.rows.to_s).to include(offer.title)
+    expect(decorator.rows.to_s).to include(member.user.username)
+    expect(decorator.rows.to_s).to include(category.to_s)
+  end
+end

--- a/spec/decorators/report/member_decorator_spec.rb
+++ b/spec/decorators/report/member_decorator_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe Report::MemberDecorator do
       User.human_attribute_name(:alt_phone),
       User.human_attribute_name(:created_at),
       User.human_attribute_name(:last_sign_in_at),
-      User.human_attribute_name(:locale),
-      Account.human_attribute_name(:balance)
     ])
   end
 
@@ -37,8 +35,6 @@ RSpec.describe Report::MemberDecorator do
         member.user.alt_phone,
         member.user.created_at.to_s,
         member.user.last_sign_in_at.to_s,
-        member.user.locale,
-        member.account_balance.to_s
       ]
     ])
   end

--- a/spec/decorators/report/post_decorator_spec.rb
+++ b/spec/decorators/report/post_decorator_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Report::PostDecorator do
 
   it "#headers" do
     expect(decorator.headers).to eq([
-      "",
       Offer.model_name.human,
       Post.human_attribute_name(:tag_list),
       User.model_name.human,
@@ -38,7 +37,7 @@ RSpec.describe Report::PostDecorator do
 
     expect(decorator.rows).to eq([
       ["", category.name, "", "", ""],
-      [offer.id, offer.title, offer.tag_list.to_s, "#{offer.user} (#{offer.member_uid})", offer.created_at.to_s]
+      [offer.title, offer.tag_list.to_s, "#{offer.user} (#{offer.member_uid})", offer.created_at.to_s]
     ])
   end
 end


### PR DESCRIPTION
As agreed with @sseerrggii, the administrator can download a detailed CSV and will be able to obtain all the information shown in [this table](https://docs.google.com/document/d/1s1kVx7UVZ02EqiyBZA827cGYHFUKIddPCUWn9Tj166U/edit?usp=sharing). The "locale" and "balance" attributes of members and the "id" attribute of posts have also been deleted from the "friendly" reports.

Here you can see a demo.

https://user-images.githubusercontent.com/70280187/119259899-a45bbf80-bbd0-11eb-83ea-b22ce2dcc456.mp4

closes #596.