### PR TITLE
Add avatar file size validation (max 5 MB)

### DIFF
--- a/app/assets/javascripts/application/avatar.js
+++ b/app/assets/javascripts/application/avatar.js
@@ -38,14 +38,14 @@ $(function () {
 
     // on submit take the parameters of the box to crop the avatar
     $('#form_photo').on("submit", () => {
-      let total_width = parseInt(getComputedStyle(document.getElementById("containerCrop")).width);
-      let photo_width = parseInt(getComputedStyle(document.getElementById("foto")).width);
+      let total_width = parseInt(getComputedStyle(document.getElementById("container_crop")).width);
+      let photo_width = parseInt(getComputedStyle(document.getElementById("original_img")).width);
       let left_displacement = total_width - photo_width;
 
       $('#height_offset').val(parseInt(panel.css('top')) - 15);
       $('#width_offset').val(parseInt(panel.css('left'))  - 15 - (left_displacement/2));
       $('#height_width').val(parseInt(panel.css('width')));
-      $('#original_width').val($('#foto').width());
+      $('#original_width').val($('#original_img').width());
     });
 
     function resize(e) {
@@ -93,7 +93,7 @@ $(function () {
     }
 
     function preview_image_modal() {
-      var preview = document.querySelector('#foto');
+      var preview = document.querySelector('#original_img');
       var file = document.querySelector('#avatar-js').files[0];
       var reader = new FileReader();
 

--- a/app/assets/stylesheets/application/avatar.scss
+++ b/app/assets/stylesheets/application/avatar.scss
@@ -6,8 +6,8 @@
 
 #crop_panel {
   position: absolute;
-  width: 140px;
-  height: 140px;
+  width: 200px;
+  height: 200px;
   border-left: 4px dashed black;
   cursor: move;
   touch-action: none;
@@ -21,7 +21,7 @@
   right: 0;
   width: 16px;
   height: 100%;
-  cursor: w-resize;
+  cursor: ew-resize;
 }
 
 #crop_panel::after {
@@ -32,5 +32,5 @@
   bottom: 0;
   width: 100%;
   height: 16px;
-  cursor: n-resize;
+  cursor: ns-resize;
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,6 @@ class User < ApplicationRecord
     :timeoutable
   ]
 
-  AVATAR_MAX_SIZE = 5
-  AVATAR_CONTENT_TYPES = %w[image/jpeg image/pjpeg image/png image/x-png]
   GENDERS = %w(
     female
     male

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
     :timeoutable
   ]
 
+  AVATAR_MAX_SIZE = 5
+  AVATAR_CONTENT_TYPES = %w[image/jpeg image/pjpeg image/png image/x-png]
   GENDERS = %w(
     female
     male

--- a/app/services/avatar_generator.rb
+++ b/app/services/avatar_generator.rb
@@ -1,0 +1,51 @@
+class AvatarGenerator
+  MAX_SIZE = 5
+  CONTENT_TYPES = %w[image/jpeg image/pjpeg image/png image/x-png]
+
+  attr_accessor :errors
+
+  def initialize(user, params)
+    @user   = user
+    @params = params
+    @avatar = params[:avatar]
+    @errors = []
+
+    validate_avatar
+  end
+
+  def call
+    @user.avatar.purge if @user.avatar.attached?
+
+    @user.avatar.attach(
+      io: process_image,
+      filename: @user.username,
+      content_type: @avatar.content_type
+    )
+  end
+
+  private
+
+  def process_image
+    orig_width = @params[:original_width].to_i
+    width      = @params[:height_width].to_i
+    left       = @params[:width_offset].to_i
+    top        = @params[:height_offset].to_i
+
+    ImageProcessing::MiniMagick.
+      source(@avatar.tempfile).
+      resize_to_fit(orig_width, nil).
+      crop("#{width}x#{width}+#{left}+#{top}!").
+      convert("png").
+      call
+  end
+
+  def validate_avatar
+    if CONTENT_TYPES.exclude?(@avatar.content_type)
+      @errors << I18n.t("users.show.invalid_format")
+    end
+
+    if @avatar.size.to_f > MAX_SIZE.megabytes
+      @errors << I18n.t("users.avatar.max_size_warning", size: MAX_SIZE)
+    end
+  end
+end

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -5,7 +5,7 @@
     <button type="button" class="close" data-dismiss="alert">x</button>
     <ul>
       <li>
-        <%= value %>
+        <%= value.html_safe %>
       </li>
     </ul>
   </div>

--- a/app/views/users/_avatar.html.erb
+++ b/app/views/users/_avatar.html.erb
@@ -16,25 +16,24 @@
         <div class="modal-dialog">
           <div class="modal-content">
             <div class="modal-header">
-              <h4 class="modal-title">
-                <%= t ".crop_the_image" %>
-              </h4>
+              <h4 class="modal-title"><%= t ".crop_the_image" %></h4>
             </div>
             <div class="modal-body">
-              <div id="containerCrop" class="col-12">
+              <div id="container_crop" class="col-12">
                 <div id="crop_panel"></div>
-                <img id="foto" alt="" />
+                <img id="original_img">
               </div>
             </div>
             <div class="modal-footer">
               <div class="form-actions">
-                <button type="button" class="btn btn-default" data-dismiss="modal">
-                  <%= t 'users.new.cancel' %>
-                </button>
-                <%= f.hidden_field :height_width, value: 140 %>
+                <%= f.hidden_field :height_width, value: 200 %>
                 <%= f.hidden_field :width_offset, value: 1 %>
                 <%= f.hidden_field :height_offset, value: 1 %>
                 <%= f.hidden_field :original_width, value: 1 %>
+
+                <%= f.button :submit, class: "btn btn-default", data: { dismiss: "modal" } do %>
+                  <%= t("users.new.cancel") %>
+                <% end %>
                 <%= f.button :submit, class: "btn btn-primary" do %>
                   <%= t("global.save") %>
                 <% end %>

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -505,6 +505,7 @@ ca:
     avatar:
       change_your_image: Canvia la teva imatge
       crop_the_image: Retalla la imatge
+      max_size_warning: La imatge és massa gran, el màxim permès és de %{size}MB
     edit:
       edit_user: Canviar usuari
     form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,6 +502,10 @@ en:
     new:
       error_amount: Time must be greater than 0
   users:
+    avatar:
+      change_your_image: Change your image
+      crop_the_image: Crop the image
+      max_size_warning: Image is too big, max allowed is %{size}MB
     edit:
       edit_user: Update user
     form:
@@ -526,9 +530,6 @@ en:
       create_more_users_button: Create and add another user
       new_user: New user
       user_created_add: User %{uid} %{name} saved, now create next one
-    avatar:
-      change_your_image: Change your image
-      crop_the_image: Crop the image
     show:
       account: Last transactions
       accounts: Accounts

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -505,6 +505,7 @@ es:
     avatar:
       change_your_image: Cambia tu imagen
       crop_the_image: Recortar la imagen
+      max_size_warning: La imagen es demasiado grande, el máximo permitido es %{size}MB
     edit:
       edit_user: Cambiar usuario
     form:

--- a/config/locales/eu.yml
+++ b/config/locales/eu.yml
@@ -505,6 +505,7 @@ eu:
     avatar:
       change_your_image: 
       crop_the_image: 
+      max_size_warning: 
     edit:
       edit_user: Erabiltzailea aldatu
     form:

--- a/config/locales/gl.yml
+++ b/config/locales/gl.yml
@@ -505,6 +505,7 @@ gl:
     avatar:
       change_your_image: 
       crop_the_image: 
+      max_size_warning: 
     edit:
       edit_user: Actualizar persoa usuaria
     form:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -505,6 +505,7 @@ pt-BR:
     avatar:
       change_your_image: 
       crop_the_image: 
+      max_size_warning: 
     edit:
       edit_user: Trocar usuário
     form:

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -433,7 +433,7 @@ RSpec.describe UsersController do
       end
 
       it "don't change the photo attached if the file size it too big" do
-        allow_any_instance_of(ActionDispatch::Http::UploadedFile).to receive(:size) { User::AVATAR_MAX_SIZE.megabytes + 1.megabyte }
+        allow_any_instance_of(ActionDispatch::Http::UploadedFile).to receive(:size) { AvatarGenerator::MAX_SIZE.megabytes + 1.megabyte }
 
         put :update_avatar, params: { avatar: uploaded_file }
 


### PR DESCRIPTION
Closes #644 

Finally, instead of extra js and new gems, I implemented the size validation using 10 lines of Ruby ✨  (see `validate_avatar(file)`), following the current approach. It also includes i18n warning: 

![Captura de pantalla 2021-06-16 a las 1 42 15](https://user-images.githubusercontent.com/576701/122137067-1a57ed00-ce44-11eb-8dc4-b1c37c2bf58c.png)



