### PR TITLE
[Feat] Confirmation email and new petitions emails

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -129,4 +129,10 @@ class ApplicationController < ActionController::Base
       redirect_to select_organization_path
     end
   end
+
+  def user_should_be_confirmed
+    return if current_user.confirmed?
+
+    redirect_to please_confirm_users_path
+  end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,5 +1,6 @@
 class OrganizationsController < ApplicationController
   before_action :load_resource, only: [:show, :edit, :update, :set_current]
+  before_action :user_should_be_confirmed
 
   def index
     if current_user

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -1,8 +1,13 @@
 class PetitionsController < ApplicationController
+  before_action :authenticate_user!
+
   def create
     petition = Petition.new petition_params
 
     if petition.save
+      OrganizationNotifier.new_petition(petition).deliver_now
+      OrganizationNotifier.petition_sent(petition).deliver_now
+
       flash[:notice] = 'Application sent'
     else
       flash[:error] = 'Something went wrong'

--- a/app/mailers/organization_notifier.rb
+++ b/app/mailers/organization_notifier.rb
@@ -12,4 +12,27 @@ class OrganizationNotifier < ActionMailer::Base
       mail(bcc: users.map(&:email))
     end
   end
+
+  def new_petition(petition)
+    @user = petition.user
+    organization = petition.organization
+
+    I18n.with_locale(locale) do
+      mail(
+        subject: 'New Application',
+        to: organization.users.joins(:members).where(members: { manager: true }).pluck(:email).uniq
+      )
+    end
+  end
+
+  def petition_sent(petition)
+    @organization_name = petition.organization.name
+
+    I18n.with_locale(locale) do
+      mail(
+        subject: 'Application sent correctly',
+        to: petition.user.email
+      )
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,7 +102,7 @@ class User < ApplicationRecord
     # this will be updated to user.id@example.com later on
     self.empty_email = email.strip.empty?
     self.email = "user#{DateTime.now.strftime('%Q')}@example.com" if empty_email && !from_signup
-    skip_confirmation! # auto-confirm, not sending confirmation email
+    skip_confirmation! unless from_signup?
     save
   end
 

--- a/app/views/organization_notifier/new_petition.html.erb
+++ b/app/views/organization_notifier/new_petition.html.erb
@@ -1,0 +1,1 @@
+Hello! New petition from user <%= @user.username %>. manage your applications <%= link_to 'here', manage_petitions_url %>.

--- a/app/views/organization_notifier/petition_sent.html.erb
+++ b/app/views/organization_notifier/petition_sent.html.erb
@@ -1,0 +1,1 @@
+Hello! your application to <%= @organization_name %> has been sent correctly.

--- a/app/views/users/please_confirm.html.erb
+++ b/app/views/users/please_confirm.html.erb
@@ -1,0 +1,2 @@
+<h1>Please, confirm the email</h1>
+An email has been sent to <%= current_user.email %>. After confirm you will be able to apply to any organization.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
     collection do
       get 'signup'
       get 'manage'
+      get 'please_confirm'
     end
   end
   put :update_avatar, to: 'users#update_avatar'


### PR DESCRIPTION
### Changes
- The confirmation is not skipped if the user was created from signup
- A confirmation email is sent automatically after signup
- If no confirmed the user will see only a `please_confirm` view
- Signup view can't be visited when logged
- When applying to a new organization two emails are sent. One to the user confirming and the other one to the organization admins.