### PR TITLE
fix locale was not set until terms acceptance, so the locale selected was lost

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,10 @@ class ApplicationController < ActionController::Base
   MissingTOSAcceptance = Class.new(Exception)
   OutadedTOSAcceptance = Class.new(Exception)
 
-  append_before_action :check_for_terms_acceptance!, unless: :devise_controller?
+  before_action :set_locale
+  before_action :check_for_terms_acceptance!, unless: :devise_controller?
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :set_locale,
-                :set_current_organization,
+  before_action :set_current_organization,
                 :store_user_location
 
   rescue_from MissingTOSAcceptance, OutadedTOSAcceptance do


### PR DESCRIPTION
`set_locale` was called after `check_for_terms_acceptance!` before action.
So the locale was never saved until terms acceptance, causing some flash messages in wrong locale (ex: timeout session).

For more clarity, I also renamed `append_before_action` into `before_action` (because it is just an alias). 

I think it solves #694 