### PR TITLE
adds petition button on organizations/show page, plus bug fix and security fix

### DIFF
--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -3,6 +3,7 @@ class PetitionsController < ApplicationController
 
   def create
     petition = Petition.new petition_params
+    petition.status = "pending"
 
     if petition.save
       OrganizationNotifier.new_petition(petition).deliver_now
@@ -13,7 +14,7 @@ class PetitionsController < ApplicationController
       flash[:error] = t('errors.internal_server_error.description')
     end
 
-    redirect_to organizations_path
+    redirect_back fallback_location: organization_path(petition.organization)
   end
 
   def update
@@ -38,6 +39,6 @@ class PetitionsController < ApplicationController
   private
 
   def petition_params
-    params.permit(%i[organization_id user_id status])
+    params.permit(%i[organization_id user_id])
   end
 end

--- a/app/views/organizations/_organizations_row.html.erb
+++ b/app/views/organizations/_organizations_row.html.erb
@@ -5,23 +5,6 @@
   <td><%= link_to(org.web, org.web) if org.web.present? %></td>
   <td><%= org.members.count %></td>
   <td>
-    <% if current_user %>
-      <% petition = current_user.petitions.where(organization_id: org.id).last %>
-
-      <% if member = Member.where(user: current_user, organization: org).first %>
-        <%= link_to t('users.user_rows.delete_membership'),
-              member,
-              method: :delete,
-              data: { confirm: t('users.user_rows.sure_delete', organization_name: org.name) },
-              class: 'btn btn-danger' %>
-      <% elsif petition && !current_user.was_member?(petition) %>
-        <span class="badge"><%= petition.status %></span>
-      <% else %>
-        <%= link_to t('petitions.apply'),
-              petitions_path(user_id: current_user.id, organization_id: org.id, status: 'pending'),
-              method: :post,
-              class: 'btn btn-default' %>
-      <% end %>
-    <% end %>
+    <%= render "organizations/petition_button", organization: org %>
   </td>
 </tr>

--- a/app/views/organizations/_petition_button.html.erb
+++ b/app/views/organizations/_petition_button.html.erb
@@ -1,0 +1,18 @@
+<% if current_user %>
+  <% petition = current_user.petitions.where(organization_id: organization.id).last %>
+
+  <% if member = Member.where(user: current_user, organization: organization).first %>
+    <%= link_to t('users.user_rows.delete_membership'),
+          member,
+          method: :delete,
+          data: { confirm: t('users.user_rows.sure_delete', organization_name: organization.name) },
+          class: 'btn btn-danger' %>
+  <% elsif petition && !current_user.was_member?(petition) %>
+    <span class="badge"><%= petition.status %></span>
+  <% else %>
+    <%= link_to t('petitions.apply'),
+          petitions_path(user_id: current_user.id, organization_id: organization.id),
+          method: :post,
+          class: 'btn btn-default' %>
+  <% end %>
+<% end %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -84,7 +84,7 @@
   </div>
   <div class="col-sm-5">
     <ul class="nav nav-pills pull-right">
-      <% if admin? %>
+      <% if current_user&.manages?(@organization) %>
         <li>
           <%= link_to edit_organization_path(@organization) do %>
             <%= glyph :pencil %>
@@ -101,6 +101,7 @@
         </li>
       <% end %>
     </ul>
+    <%= render "organizations/petition_button", organization: @organization %>
   </div>
 </div>
 

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -7,9 +7,12 @@ RSpec.describe PetitionsController do
     before { login(user) }
 
     it 'creates the petition' do
+      request.env['HTTP_REFERER'] = organizations_path
+
       expect do
         post :create, params: { user_id: user.id, organization_id: organization.id }
       end.to change(Petition, :count).by(1)
+      expect(response).to redirect_to(organizations_path)
     end
   end
 
@@ -35,7 +38,7 @@ RSpec.describe PetitionsController do
 
   describe 'GET #manage' do
     before do
-      allow(controller).to receive(:current_organization) { organization } 
+      allow(controller).to receive(:current_organization) { organization }
       login(admin.user)
     end
     let!(:petition) { Petition.create(user: user, organization: organization, status: 'pending') }

--- a/spec/views/organizations/show.html.erb_spec.rb
+++ b/spec/views/organizations/show.html.erb_spec.rb
@@ -59,5 +59,63 @@ RSpec.describe 'organizations/show' do
     it 'displays the organization page' do
       expect(rendered).to match(organization.name)
     end
+
+    it 'displays link to delete the member' do
+      expect(rendered).to have_link(
+        t('users.user_rows.delete_membership'),
+        href: member_path(member)
+      )
+    end
+  end
+
+  context 'with a logged user (but not organization member)' do
+    let(:user) { Fabricate(:user) }
+
+    before do
+      allow(view).to receive(:current_user).and_return(user)
+
+      assign :movements, Movement.page
+      render template: 'organizations/show'
+    end
+
+    it 'displays link to create petition' do
+      expect(rendered).to have_link(
+        t('petitions.apply'),
+        href: petitions_path(user_id: user.id, organization_id: organization.id)
+      )
+    end
+  end
+
+  context 'with a logged admin' do
+    let(:admin) { Fabricate(:member, organization: organization, manager: true) }
+    let(:user) { admin.user }
+
+    before do
+      allow(view).to receive(:current_user).and_return(user)
+
+      assign :movements, Movement.page
+      render template: 'organizations/show'
+    end
+
+    it 'has link to edit organization' do
+      expect(rendered).to have_link(t('global.edit'), href: edit_organization_path(organization))
+    end
+  end
+
+  context 'with a logged admin from other organization' do
+    let(:other_organization) { Fabricate(:organization) }
+    let(:admin) { Fabricate(:member, organization: other_organization, manager: true) }
+    let(:user) { admin.user }
+
+    before do
+      allow(view).to receive(:current_user).and_return(user)
+
+      assign :movements, Movement.page
+      render template: 'organizations/show'
+    end
+
+    it 'does not have link to edit organization' do
+      expect(rendered).to_not have_link(t('global.edit'), href: edit_organization_path(organization))
+    end
   end
 end


### PR DESCRIPTION
**Security fix:** 
do not let client side send the petition status, controller should define it 

**Improvements:**
New petition button and destroy member buttons are extracted into a partial and use in organizations/show page.

**Bug fix:**
An admin on an organization A was seeing "edit organization button" on organizations/show page of organization B.

Closes #715 