### PR TITLE
[FIX] Import transfer: movements & transfer with the same created_at

### DIFF
--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -23,8 +23,8 @@ class Transfer < ApplicationRecord
   after_create :make_movements
 
   def make_movements
-    movements.create(account: Account.find(source_id), amount: -amount.to_i)
-    movements.create(account: Account.find(destination_id), amount: amount.to_i)
+    movements.create(account: Account.find(source_id), amount: -amount.to_i, created_at: created_at)
+    movements.create(account: Account.find(destination_id), amount: amount.to_i, created_at: created_at)
   end
 
   def source_id


### PR DESCRIPTION
### Changes

- now when te movements are created they use the same created at as the transfer

**Note:** If we didn't want to touch the rest of the app and only make this change in the import, we could use `transfer.movements.update_all(created_at: transfer.created_at)` in `process_row` after the transfer save. However, I believe it makes more sense as I placed it, to ensure consistency between transfer and movements at all times