### PR TITLE
Acceptance between administrators

### DIFF
--- a/app/controllers/organization_alliances_controller.rb
+++ b/app/controllers/organization_alliances_controller.rb
@@ -1,0 +1,79 @@
+class OrganizationAlliancesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :member_should_exist_and_be_active
+  before_action :authorize_admin
+  before_action :find_alliance, only: [:update, :destroy]
+
+  def index
+    @status = params[:status] || "pending"
+
+    @alliances = case @status
+                 when "pending"
+                   current_organization.pending_sent_alliances.includes(:source_organization, :target_organization) +
+                   current_organization.pending_received_alliances.includes(:source_organization, :target_organization)
+                 when "accepted"
+                   current_organization.accepted_alliances.includes(:source_organization, :target_organization)
+                 when "rejected"
+                   current_organization.rejected_alliances.includes(:source_organization, :target_organization)
+                 else
+                   []
+                 end
+  end
+
+  def create
+    @alliance = OrganizationAlliance.new(
+      source_organization: current_organization,
+      target_organization_id: params[:organization_alliance][:target_organization_id],
+      status: "pending"
+    )
+
+    if @alliance.save
+      flash[:notice] = t("organization_alliances.created")
+    else
+      flash[:error] = @alliance.errors.full_messages.to_sentence
+    end
+
+    redirect_back fallback_location: organizations_path
+  end
+
+  def update
+    authorize @alliance
+
+    if @alliance.update(status: params[:status])
+      flash[:notice] = t("organization_alliances.updated")
+    else
+      flash[:error] = @alliance.errors.full_messages.to_sentence
+    end
+
+    redirect_to organization_alliances_path
+  end
+
+  def destroy
+    authorize @alliance
+
+    if @alliance.destroy
+      flash[:notice] = t("organization_alliances.destroyed")
+    else
+      flash[:error] = t("organization_alliances.error_destroying")
+    end
+
+    redirect_to organization_alliances_path
+  end
+
+  private
+
+  def find_alliance
+    @alliance = OrganizationAlliance.find(params[:id])
+  end
+
+  def authorize_admin
+    unless current_user.manages?(current_organization)
+      flash[:error] = t("organization_alliances.not_authorized")
+      redirect_to root_path
+    end
+  end
+
+  def alliance_params
+    params.require(:organization_alliance).permit(:target_organization_id)
+  end
+end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -24,6 +24,8 @@ class Organization < ApplicationRecord
   has_many :inquiries
   has_many :documents, as: :documentable, dependent: :destroy
   has_many :petitions, dependent: :delete_all
+  has_many :source_alliances, class_name: "OrganizationAlliance", foreign_key: "source_organization_id", dependent: :destroy
+  has_many :target_alliances, class_name: "OrganizationAlliance", foreign_key: "target_organization_id", dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
 
@@ -59,6 +61,27 @@ class Organization < ApplicationRecord
   # @return [Integer | String]
   def display_id
     account.accountable_id
+  end
+
+  def alliance_with(organization)
+    source_alliances.find_by(target_organization: organization) ||
+      target_alliances.find_by(source_organization: organization)
+  end
+
+  def pending_sent_alliances
+    source_alliances.pending
+  end
+
+  def pending_received_alliances
+    target_alliances.pending
+  end
+
+  def accepted_alliances
+    source_alliances.accepted.or(target_alliances.accepted)
+  end
+
+  def rejected_alliances
+    source_alliances.rejected.or(target_alliances.rejected)
   end
 
   def ensure_reg_number_seq!

--- a/app/models/organization_alliance.rb
+++ b/app/models/organization_alliance.rb
@@ -1,0 +1,23 @@
+class OrganizationAlliance < ApplicationRecord
+  belongs_to :source_organization, class_name: "Organization"
+  belongs_to :target_organization, class_name: "Organization"
+
+  enum status: { pending: 0, accepted: 1, rejected: 2 }
+
+  validates :source_organization_id, presence: true
+  validates :target_organization_id, presence: true
+  validates :target_organization_id, uniqueness: { scope: :source_organization_id }
+  validate :cannot_ally_with_self
+
+  scope :pending, -> { where(status: "pending") }
+  scope :accepted, -> { where(status: "accepted") }
+  scope :rejected, -> { where(status: "rejected") }
+
+  private
+
+  def cannot_ally_with_self
+    if source_organization_id == target_organization_id
+      errors.add(:base, "Cannot create an alliance with yourself")
+    end
+  end
+end

--- a/app/policies/organization_alliance_policy.rb
+++ b/app/policies/organization_alliance_policy.rb
@@ -1,0 +1,11 @@
+class OrganizationAlliancePolicy < ApplicationPolicy
+  def update?
+    alliance = record
+    user.manages?(alliance.source_organization) || user.manages?(alliance.target_organization)
+  end
+
+  def destroy?
+    alliance = record
+    user.manages?(alliance.source_organization) || user.manages?(alliance.target_organization)
+  end
+end

--- a/app/views/application/menus/_organization_listings_menu.html.erb
+++ b/app/views/application/menus/_organization_listings_menu.html.erb
@@ -17,6 +17,12 @@
       <% end %>
     </li>
     <li>
+      <%= link_to organization_alliances_path, class: "dropdown-item" do %>
+        <%= glyph :globe %>
+        <%= t "application.navbar.organization_alliances" %>
+      <% end %>
+    </li>
+    <li>
       <%= link_to offers_path(org: current_organization), class: "dropdown-item" do %>
         <%= glyph :link %>
         <%= glyph :eye_open %>

--- a/app/views/organization_alliances/index.html.erb
+++ b/app/views/organization_alliances/index.html.erb
@@ -1,0 +1,102 @@
+<h1><%= t('organization_alliances.title') %></h1>
+
+<div class="row">
+  <div class="col-12 col-sm-12 col-md-12 col-lg-12">
+    <ul class="nav nav-pills actions-menu">
+      <li class="nav-item">
+        <%= link_to organization_alliances_path(status: 'pending'), class: "nav-link #{'active' if @status == 'pending'}" do %>
+          <%= glyph :time %>
+          <%= t('organization_alliances.status.pending') %>
+        <% end %>
+      </li>
+      <li class="nav-item">
+        <%= link_to organization_alliances_path(status: 'accepted'), class: "nav-link #{'active' if @status == 'accepted'}" do %>
+          <%= glyph :ok %>
+          <%= t('organization_alliances.status.accepted') %>
+        <% end %>
+      </li>
+      <li class="nav-item">
+        <%= link_to organization_alliances_path(status: 'rejected'), class: "nav-link #{'active' if @status == 'rejected'}" do %>
+          <%= glyph :remove %>
+          <%= t('organization_alliances.status.rejected') %>
+        <% end %>
+      </li>
+      <li class="nav-item ms-auto">
+        <%= link_to organizations_path, class: "text-primary" do %>
+          <%= glyph :search %>
+          <%= t('organization_alliances.search_organizations') %>
+        <% end %>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="card">
+      <div class="card-body table-responsive">
+        <table class="table table-hover table-sm">
+          <thead>
+            <tr>
+              <th><%= t('organization_alliances.organization') %></th>
+              <th><%= t('organization_alliances.city') %></th>
+              <th><%= t('organization_alliances.members') %></th>
+              <th><%= t('organization_alliances.type') %></th>
+              <% if @status != 'rejected' %>
+                <th><%= t('organization_alliances.actions') %></th>
+              <% end %>
+            </tr>
+          </thead>
+          <tbody>
+            <% @alliances.each do |alliance| %>
+              <% is_sender = (alliance.source_organization_id == current_organization.id) %>
+              <% other_org = is_sender ? alliance.target_organization : alliance.source_organization %>
+              <tr>
+                <td><%= link_to other_org.name, other_org %></td>
+                <td><%= other_org.city %></td>
+                <td><%= other_org.members.count %></td>
+                <td>
+                  <% if is_sender %>
+                    <%= t('organization_alliances.sent') %>
+                  <% else %>
+                    <%= t('organization_alliances.received') %>
+                  <% end %>
+                </td>
+                <% if @status == 'pending' %>
+                  <td>
+                    <% if is_sender %>
+                      <%= link_to t('organization_alliances.cancel_request'),
+                          organization_alliance_path(alliance),
+                          method: :delete,
+                          class: 'btn btn-danger',
+                          data: { confirm: t('organization_alliances.confirm_cancel') } %>
+                    <% else %>
+                      <div class="btn-group" role="group" aria-label="Alliance actions">
+                        <%= link_to t('organization_alliances.accept'),
+                            organization_alliance_path(alliance, status: 'accepted'),
+                            method: :put,
+                            class: 'btn btn-success me-2' %>
+                        <%= link_to t('organization_alliances.reject'),
+                            organization_alliance_path(alliance, status: 'rejected'),
+                            method: :put,
+                            class: 'btn btn-danger' %>
+                      </div>
+                    <% end %>
+                  </td>
+                <% elsif @status == 'accepted' %>
+                  <td>
+                    <%= link_to t('organization_alliances.end_alliance'),
+                        organization_alliance_path(alliance),
+                        method: :delete,
+                        class: 'btn btn-danger',
+                        data: { confirm: t('organization_alliances.confirm_end') } %>
+                  </td>
+                <% end %>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/organization_alliances/index.html.erb
+++ b/app/views/organization_alliances/index.html.erb
@@ -71,11 +71,11 @@
                           class: 'btn btn-danger',
                           data: { confirm: t('organization_alliances.confirm_cancel') } %>
                     <% else %>
-                      <div class="btn-group" role="group" aria-label="Alliance actions">
+                      <div>
                         <%= link_to t('organization_alliances.accept'),
                             organization_alliance_path(alliance, status: 'accepted'),
                             method: :put,
-                            class: 'btn btn-success me-2' %>
+                            class: 'btn btn-primary' %>
                         <%= link_to t('organization_alliances.reject'),
                             organization_alliance_path(alliance, status: 'rejected'),
                             method: :put,

--- a/app/views/organizations/_alliance_button.html.erb
+++ b/app/views/organizations/_alliance_button.html.erb
@@ -1,0 +1,16 @@
+<% if current_user&.manages?(current_organization) && organization != current_organization %>
+  <% alliance = current_organization.alliance_with(organization) %>
+  <% if alliance.nil? %>
+    <%= link_to t('organization_alliances.request_alliance'),
+          organization_alliances_path(organization_alliance: { target_organization_id: organization.id }),
+          method: :post,
+          class: 'btn btn-secondary',
+          aria: { label: t('organization_alliances.request_alliance_for', org: organization.name) } %>
+  <% elsif alliance.pending? %>
+    <span class="badge rounded-pill bg-secondary"><%= t('organization_alliances.pending') %></span>
+  <% elsif alliance.accepted? %>
+    <span class="badge rounded-pill bg-success"><%= t('organization_alliances.active') %></span>
+  <% elsif alliance.rejected? %>
+    <span class="badge rounded-pill bg-danger"><%= t('organization_alliances.rejected') %></span>
+  <% end %>
+<% end %>

--- a/app/views/organizations/_alliance_button.html.erb
+++ b/app/views/organizations/_alliance_button.html.erb
@@ -9,7 +9,7 @@
   <% elsif alliance.pending? %>
     <span class="badge rounded-pill bg-secondary"><%= t('organization_alliances.pending') %></span>
   <% elsif alliance.accepted? %>
-    <span class="badge rounded-pill bg-success"><%= t('organization_alliances.active') %></span>
+    <span class="badge rounded-pill bg-primary"><%= t('organization_alliances.active') %></span>
   <% elsif alliance.rejected? %>
     <span class="badge rounded-pill bg-danger"><%= t('organization_alliances.rejected') %></span>
   <% end %>

--- a/app/views/organizations/_organizations_row.html.erb
+++ b/app/views/organizations/_organizations_row.html.erb
@@ -7,4 +7,9 @@
   <td>
     <%= render "organizations/petition_button", organization: org %>
   </td>
+  <% if current_user&.manages?(current_organization) %>
+    <td>
+      <%= render "organizations/alliance_button", organization: org %>
+    </td>
+  <% end %>
 </tr>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -25,7 +25,10 @@
           <th><%= t '.neighborhood' %></th>
           <th><%= t '.web' %></th>
           <th><%= t '.member_count' %></th>
-          <th></th>
+          <th><%= t '.membership' %></th>
+          <% if current_user&.manages?(current_organization) %>
+            <th><%= t '.alliance' %></th>
+          <% end %>
         </tr>
       </thead>
       <tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,7 @@ en:
       last_login: Last login
       offer_public_link: Offers public link
       organizations: Organizations
+      organization_alliances: Organizations
       reports: Reports
       sign_out: Logout
       statistics: Statistics
@@ -370,6 +371,35 @@ en:
     show:
       give_time_for: Time transfer for this offer
       offered_by: Offered by
+  organization_alliances:
+    title: "Organization Alliances"
+    created: "Alliance request sent"
+    updated: "Alliance status updated"
+    destroyed: "Alliance has been ended"
+    error_destroying: "Could not end alliance"
+    not_authorized: "You are not authorized to manage alliances"
+    organization: "Organization"
+    city: "City"
+    members: "Members"
+    type: "Type"
+    actions: "Actions"
+    sent: "Sent"
+    received: "Received"
+    pending: "Pending"
+    active: "Active"
+    rejected: "Rejected"
+    request_alliance: "Request alliance"
+    cancel_request: "Cancel request"
+    accept: "Accept"
+    reject: "Reject"
+    end_alliance: "End alliance"
+    confirm_cancel: "Are you sure you want to cancel this alliance request?"
+    confirm_end: "Are you sure you want to end this alliance?"
+    search_organizations: "Search organizations"
+    status:
+      pending: "Pending Requests"
+      accepted: "Active Alliances"
+      rejected: "Rejected Requests"
   organization_notifier:
     member_deleted:
       body: User %{username} has unsubscribed from the organization.
@@ -382,6 +412,8 @@ en:
       give_time: Give time to
     index:
       member_count: Number of users
+      membership: "Membership"
+      alliance: "Alliance"
     new:
       new: New bank
     show:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -141,6 +141,7 @@ es:
       last_login: Último login
       offer_public_link: Enlace público a ofertas
       organizations: Organizaciones
+      organization_alliances: Organizaciones
       reports: Informes
       sign_out: Desconectar
       statistics: Estadísticas
@@ -370,6 +371,35 @@ es:
     show:
       give_time_for: Transferir tiempo por esta oferta
       offered_by: Ofertantes
+  organization_alliances:
+    title: "Alianzas"
+    created: "Solicitud de alianza enviada"
+    updated: "Estado de alianza actualizado"
+    destroyed: "La alianza ha finalizado"
+    error_destroying: "No se pudo finalizar la alianza"
+    not_authorized: "No estás autorizado para gestionar alianzas"
+    organization: "Organización"
+    city: "Ciudad"
+    members: "Miembros"
+    type: "Tipo"
+    actions: "Acciones"
+    sent: "Enviadas"
+    received: "Recibidas"
+    pending: "Pending"
+    active: "Activa"
+    rejected: "Rechazada"
+    request_alliance: "Solicitar alianza"
+    cancel_request: "Cancelar solicitud"
+    accept: "Aceptar"
+    reject: "Rechazar"
+    end_alliance: "Finalizar alianza"
+    confirm_cancel: "¿Estás seguro de que quieres cancelar esta solicitud de alianza?"
+    confirm_end: "¿Estás seguro de que quieres finalizar esta alianza?"
+    search_organizations: "Buscar organizaciones"
+    status:
+      pending: "Solicitudes Pendientes"
+      accepted: "Alianzas Activas"
+      rejected: "Solicitudes Rechazadas"
   organization_notifier:
     member_deleted:
       body: El usuario %{username} se ha dado de baja de la organización.
@@ -382,6 +412,8 @@ es:
       give_time: Dar Tiempo a
     index:
       member_count: Número de usuarios
+      membership: "Membresía"
+      alliance: "Alianza"
     new:
       new: Nuevo banco
     show:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
   end
   get :select_organization, to: 'organizations#select_organization'
 
+  resources :organization_alliances, only: [:index, :create, :update, :destroy] 
+    
   resources :users, concerns: :accountable, except: :destroy, :path => "members" do
     collection do
       get 'signup'

--- a/db/migrate/20250412110249_create_organization_alliances.rb
+++ b/db/migrate/20250412110249_create_organization_alliances.rb
@@ -1,0 +1,14 @@
+class CreateOrganizationAlliances < ActiveRecord::Migration[7.2]
+  def change
+    create_table :organization_alliances do |t|
+      t.references :source_organization, foreign_key: { to_table: :organizations }
+      t.references :target_organization, foreign_key: { to_table: :organizations }
+      t.integer :status, default: 0
+      
+      t.timestamps
+    end
+    
+    add_index :organization_alliances, [:source_organization_id, :target_organization_id], 
+              unique: true, name: 'index_org_alliances_on_source_and_target'
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,25 +1,13 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
+SET row_security = off;
 
 --
 -- Name: hstore; Type: EXTENSION; Schema: -; Owner: -
@@ -82,7 +70,7 @@ CREATE FUNCTION public.posts_trigger() RETURNS trigger
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: accounts; Type: TABLE; Schema: public; Owner: -
@@ -480,6 +468,39 @@ ALTER SEQUENCE public.movements_id_seq OWNED BY public.movements.id;
 
 
 --
+-- Name: organization_alliances; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_alliances (
+    id bigint NOT NULL,
+    source_organization_id bigint,
+    target_organization_id bigint,
+    status integer DEFAULT 0,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: organization_alliances_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.organization_alliances_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: organization_alliances_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.organization_alliances_id_seq OWNED BY public.organization_alliances.id;
+
+
+--
 -- Name: organizations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -819,6 +840,13 @@ ALTER TABLE ONLY public.movements ALTER COLUMN id SET DEFAULT nextval('public.mo
 
 
 --
+-- Name: organization_alliances id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_alliances ALTER COLUMN id SET DEFAULT nextval('public.organization_alliances_id_seq'::regclass);
+
+
+--
 -- Name: organizations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -954,6 +982,14 @@ ALTER TABLE ONLY public.members
 
 ALTER TABLE ONLY public.movements
     ADD CONSTRAINT movements_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: organization_alliances organization_alliances_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_alliances
+    ADD CONSTRAINT organization_alliances_pkey PRIMARY KEY (id);
 
 
 --
@@ -1145,6 +1181,27 @@ CREATE INDEX index_movements_on_transfer_id ON public.movements USING btree (tra
 
 
 --
+-- Name: index_org_alliances_on_source_and_target; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_org_alliances_on_source_and_target ON public.organization_alliances USING btree (source_organization_id, target_organization_id);
+
+
+--
+-- Name: index_organization_alliances_on_source_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_organization_alliances_on_source_organization_id ON public.organization_alliances USING btree (source_organization_id);
+
+
+--
+-- Name: index_organization_alliances_on_target_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_organization_alliances_on_target_organization_id ON public.organization_alliances USING btree (target_organization_id);
+
+
+--
 -- Name: index_organizations_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1232,7 +1289,7 @@ CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING b
 -- Name: posts tsvectorupdate; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON public.posts FOR EACH ROW EXECUTE PROCEDURE public.posts_trigger();
+CREATE TRIGGER tsvectorupdate BEFORE INSERT OR UPDATE ON public.posts FOR EACH ROW EXECUTE FUNCTION public.posts_trigger();
 
 
 --
@@ -1300,6 +1357,14 @@ ALTER TABLE ONLY public.push_notifications
 
 
 --
+-- Name: organization_alliances fk_rails_7c459bc8e7; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_alliances
+    ADD CONSTRAINT fk_rails_7c459bc8e7 FOREIGN KEY (source_organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- Name: active_storage_variant_records fk_rails_993965df05; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1316,83 +1381,93 @@ ALTER TABLE ONLY public.active_storage_attachments
 
 
 --
+-- Name: organization_alliances fk_rails_da452c7bdc; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_alliances
+    ADD CONSTRAINT fk_rails_da452c7bdc FOREIGN KEY (target_organization_id) REFERENCES public.organizations(id);
+
+
+--
 -- PostgreSQL database dump complete
 --
 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
-('1'),
-('2'),
-('20121019101022'),
-('20121104004639'),
-('20121104085711'),
-('20121121233818'),
-('20130214175758'),
-('20130214181128'),
-('20130222185624'),
-('20130425165150'),
-('20130508085004'),
-('20130513092219'),
-('20130514094755'),
-('20130618210236'),
-('20130621102219'),
-('20130621103053'),
-('20130621103501'),
-('20130621105452'),
-('20130703233851'),
-('20130703234011'),
-('20130703234042'),
-('20130723160206'),
-('20131017144321'),
-('20131025202608'),
-('20131027215517'),
-('20131029202724'),
-('20131103221044'),
-('20131104004235'),
-('20131104013634'),
-('20131104013829'),
-('20131104032622'),
-('20131220160257'),
-('20131227110122'),
-('20131227142805'),
-('20131227155440'),
-('20131231110424'),
-('20140119161433'),
-('20140513141718'),
-('20140514225527'),
-('20150329193421'),
-('20150330200315'),
-('20150422162806'),
-('20180221161343'),
-('20180501093846'),
-('20180514193153'),
-('20180524143938'),
-('20180525141138'),
-('20180529144243'),
-('20180530180546'),
-('20180604145622'),
-('20180828160700'),
-('20180831161349'),
-('20180924164456'),
-('20181004200104'),
-('20190319121401'),
-('20190322180602'),
-('20190411192828'),
-('20190412163011'),
-('20190523213421'),
-('20190523225323'),
-('20210423193937'),
-('20210424174640'),
-('20210502160343'),
-('20210503201944'),
-('20221016192111'),
-('20230312231058'),
-('20230314233504'),
-('20230401114456'),
-('20231120164231'),
-('20231120164346'),
-('20241230170753'),
-('20250215163404'),
+('20250412110249'),
+('20250215163406'),
 ('20250215163405'),
-('20250215163406');
+('20250215163404'),
+('20241230170753'),
+('20231120164346'),
+('20231120164231'),
+('20230401114456'),
+('20230314233504'),
+('20230312231058'),
+('20221016192111'),
+('20210503201944'),
+('20210502160343'),
+('20210424174640'),
+('20210423193937'),
+('20190523225323'),
+('20190523213421'),
+('20190412163011'),
+('20190411192828'),
+('20190322180602'),
+('20190319121401'),
+('20181004200104'),
+('20180924164456'),
+('20180831161349'),
+('20180828160700'),
+('20180604145622'),
+('20180530180546'),
+('20180529144243'),
+('20180525141138'),
+('20180524143938'),
+('20180514193153'),
+('20180501093846'),
+('20180221161343'),
+('20150422162806'),
+('20150330200315'),
+('20150329193421'),
+('20140514225527'),
+('20140513141718'),
+('20140119161433'),
+('20131231110424'),
+('20131227155440'),
+('20131227142805'),
+('20131227110122'),
+('20131220160257'),
+('20131104032622'),
+('20131104013829'),
+('20131104013634'),
+('20131104004235'),
+('20131103221044'),
+('20131029202724'),
+('20131027215517'),
+('20131025202608'),
+('20131017144321'),
+('20130723160206'),
+('20130703234042'),
+('20130703234011'),
+('20130703233851'),
+('20130621105452'),
+('20130621103501'),
+('20130621103053'),
+('20130621102219'),
+('20130618210236'),
+('20130514094755'),
+('20130513092219'),
+('20130508085004'),
+('20130425165150'),
+('20130222185624'),
+('20130214181128'),
+('20130214175758'),
+('20121121233818'),
+('20121104085711'),
+('20121104004639'),
+('20121019101022'),
+('2'),
+('1');
+

--- a/spec/controllers/organization_alliances_controller_spec.rb
+++ b/spec/controllers/organization_alliances_controller_spec.rb
@@ -1,0 +1,155 @@
+RSpec.describe OrganizationAlliancesController do
+  let(:organization) { Fabricate(:organization) }
+  let(:other_organization) { Fabricate(:organization) }
+  let(:member) { Fabricate(:member, organization: organization, manager: true) }
+  let(:user) { member.user }
+
+  before do
+    login(user)
+  end
+
+  describe "GET #index" do
+    let!(:pending_sent) {
+      OrganizationAlliance.create!(
+        source_organization: organization,
+        target_organization: other_organization,
+        status: "pending"
+      )
+    }
+
+    let!(:pending_received) {
+      OrganizationAlliance.create!(
+        source_organization: Fabricate(:organization),
+        target_organization: organization,
+        status: "pending"
+      )
+    }
+
+    let!(:accepted) {
+      OrganizationAlliance.create!(
+        source_organization: organization,
+        target_organization: Fabricate(:organization),
+        status: "accepted"
+      )
+    }
+
+    let!(:rejected) {
+      OrganizationAlliance.create!(
+        source_organization: organization,
+        target_organization: Fabricate(:organization),
+        status: "rejected"
+      )
+    }
+
+    it "lists pending alliances by default" do
+      get :index
+
+      expect(assigns(:status)).to eq("pending")
+      expect(assigns(:alliances)).to include(pending_sent, pending_received)
+      expect(assigns(:alliances)).not_to include(accepted, rejected)
+    end
+
+    it "lists accepted alliances when status is accepted" do
+      get :index, params: { status: "accepted" }
+
+      expect(assigns(:status)).to eq("accepted")
+      expect(assigns(:alliances)).to include(accepted)
+      expect(assigns(:alliances)).not_to include(pending_sent, pending_received, rejected)
+    end
+
+    it "lists rejected alliances when status is rejected" do
+      get :index, params: { status: "rejected" }
+
+      expect(assigns(:status)).to eq("rejected")
+      expect(assigns(:alliances)).to include(rejected)
+      expect(assigns(:alliances)).not_to include(pending_sent, pending_received, accepted)
+    end
+  end
+
+  describe "POST #create" do
+    it "creates a new alliance" do
+      expect {
+        post :create, params: { organization_alliance: { target_organization_id: other_organization.id } }
+      }.to change(OrganizationAlliance, :count).by(1)
+
+      expect(flash[:notice]).to eq(I18n.t("organization_alliances.created"))
+      expect(response).to redirect_to(organizations_path)
+    end
+
+    it "sets flash error if alliance cannot be created" do
+      # Try to create alliance with self which is invalid
+      allow_any_instance_of(OrganizationAlliance).to receive(:save).and_return(false)
+      allow_any_instance_of(OrganizationAlliance).to receive_message_chain(:errors, :full_messages, :to_sentence).and_return("Error message")
+
+      post :create, params: { organization_alliance: { target_organization_id: organization.id } }
+
+      expect(flash[:error]).to eq("Error message")
+      expect(response).to redirect_to(organizations_path)
+    end
+  end
+
+  describe "PUT #update" do
+    let!(:alliance) {
+      OrganizationAlliance.create!(
+        source_organization: Fabricate(:organization),
+        target_organization: organization,
+        status: "pending"
+      )
+    }
+
+    it "updates alliance status to accepted" do
+      put :update, params: { id: alliance.id, status: "accepted" }
+
+      alliance.reload
+      expect(alliance).to be_accepted
+      expect(flash[:notice]).to eq(I18n.t("organization_alliances.updated"))
+      expect(response).to redirect_to(organization_alliances_path)
+    end
+
+    it "updates alliance status to rejected" do
+      put :update, params: { id: alliance.id, status: "rejected" }
+
+      alliance.reload
+      expect(alliance).to be_rejected
+      expect(flash[:notice]).to eq(I18n.t("organization_alliances.updated"))
+      expect(response).to redirect_to(organization_alliances_path)
+    end
+
+    it "sets flash error if alliance cannot be updated" do
+      allow_any_instance_of(OrganizationAlliance).to receive(:update).and_return(false)
+      allow_any_instance_of(OrganizationAlliance).to receive_message_chain(:errors, :full_messages, :to_sentence).and_return("Error message")
+
+      put :update, params: { id: alliance.id, status: "accepted" }
+
+      expect(flash[:error]).to eq("Error message")
+      expect(response).to redirect_to(organization_alliances_path)
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let!(:alliance) {
+      OrganizationAlliance.create!(
+        source_organization: organization,
+        target_organization: other_organization
+      )
+    }
+
+    it "destroys the alliance" do
+      expect {
+        delete :destroy, params: { id: alliance.id }
+      }.to change(OrganizationAlliance, :count).by(-1)
+
+      expect(flash[:notice]).to eq(I18n.t("organization_alliances.destroyed"))
+      expect(response).to redirect_to(organization_alliances_path)
+    end
+
+    it "sets flash error if alliance cannot be destroyed" do
+      allow_any_instance_of(OrganizationAlliance).to receive(:destroy).and_return(false)
+
+      delete :destroy, params: { id: alliance.id }
+
+      expect(flash[:error]).to eq(I18n.t("organization_alliances.error_destroying"))
+      expect(response).to redirect_to(organization_alliances_path)
+    end
+  end
+end

--- a/spec/models/organization_alliance_spec.rb
+++ b/spec/models/organization_alliance_spec.rb
@@ -1,0 +1,121 @@
+RSpec.describe OrganizationAlliance do
+  let(:organization) { Fabricate(:organization) }
+  let(:other_organization) { Fabricate(:organization) }
+
+  around do |example|
+    I18n.with_locale(:en) do
+      example.run
+    end
+  end
+
+  describe "validations" do
+    it "is valid with valid attributes" do
+      alliance = OrganizationAlliance.new(
+        source_organization: organization,
+        target_organization: other_organization
+      )
+      expect(alliance).to be_valid
+    end
+
+    it "is not valid without a source organization" do
+      alliance = OrganizationAlliance.new(
+        source_organization: nil,
+        target_organization: other_organization
+      )
+      expect(alliance).not_to be_valid
+      expect(alliance.errors[:source_organization_id]).to include("can't be blank")
+    end
+
+    it "is not valid without a target organization" do
+      alliance = OrganizationAlliance.new(
+        source_organization: organization,
+        target_organization: nil
+      )
+      expect(alliance).not_to be_valid
+      expect(alliance.errors[:target_organization_id]).to include("can't be blank")
+    end
+
+    it "is not valid if creating an alliance with self" do
+      alliance = OrganizationAlliance.new(
+        source_organization: organization,
+        target_organization: organization
+      )
+      expect(alliance).not_to be_valid
+      expect(alliance.errors[:base]).to include("Cannot create an alliance with yourself")
+    end
+
+    it "is not valid if alliance already exists" do
+      OrganizationAlliance.create!(
+        source_organization: organization,
+        target_organization: other_organization
+      )
+
+      alliance = OrganizationAlliance.new(
+        source_organization: organization,
+        target_organization: other_organization
+      )
+      expect(alliance).not_to be_valid
+      expect(alliance.errors[:target_organization_id]).to include("has already been taken")
+    end
+  end
+
+  describe "status enum" do
+    let(:alliance) {
+      OrganizationAlliance.create!(
+        source_organization: organization,
+        target_organization: other_organization
+      )
+    }
+
+    it "defaults to pending" do
+      expect(alliance).to be_pending
+    end
+
+    it "can be set to accepted" do
+      alliance.accepted!
+      expect(alliance).to be_accepted
+    end
+
+    it "can be set to rejected" do
+      alliance.rejected!
+      expect(alliance).to be_rejected
+    end
+  end
+
+  describe "scopes" do
+    before do
+      @pending_alliance = OrganizationAlliance.create!(
+        source_organization: organization,
+        target_organization: other_organization,
+        status: "pending"
+      )
+
+      @accepted_alliance = OrganizationAlliance.create!(
+        source_organization: Fabricate(:organization),
+        target_organization: Fabricate(:organization),
+        status: "accepted"
+      )
+
+      @rejected_alliance = OrganizationAlliance.create!(
+        source_organization: Fabricate(:organization),
+        target_organization: Fabricate(:organization),
+        status: "rejected"
+      )
+    end
+
+    it "returns pending alliances" do
+      expect(OrganizationAlliance.pending).to include(@pending_alliance)
+      expect(OrganizationAlliance.pending).not_to include(@accepted_alliance, @rejected_alliance)
+    end
+
+    it "returns accepted alliances" do
+      expect(OrganizationAlliance.accepted).to include(@accepted_alliance)
+      expect(OrganizationAlliance.accepted).not_to include(@pending_alliance, @rejected_alliance)
+    end
+
+    it "returns rejected alliances" do
+      expect(OrganizationAlliance.rejected).to include(@rejected_alliance)
+      expect(OrganizationAlliance.rejected).not_to include(@pending_alliance, @accepted_alliance)
+    end
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -5,24 +5,20 @@ RSpec.describe Organization do
     it "validates content_type" do
       temp_file = Tempfile.new('test.txt')
       organization.logo.attach(io: File.open(temp_file.path), filename: 'test.txt')
-
       expect(organization).to be_invalid
 
       temp_file = Tempfile.new('test.svg')
       organization.logo.attach(io: File.open(temp_file.path), filename: 'test.svg')
-
       expect(organization).to be_invalid
 
       temp_file = Tempfile.new('test.png')
       organization.logo.attach(io: File.open(temp_file.path), filename: 'test.png')
-
       expect(organization).to be_valid
     end
   end
 
   describe '#display_id' do
     subject { organization.display_id }
-
     it { is_expected.to eq(organization.account.accountable_id) }
   end
 
@@ -69,5 +65,100 @@ RSpec.describe Organization do
     organization.name = nil
     organization.save
     expect(organization.errors[:name]).to include(I18n.t('errors.messages.blank'))
+  end
+
+  describe "alliance methods" do
+    let(:organization) { Fabricate(:organization) }
+    let(:other_organization) { Fabricate(:organization) }
+
+    describe "#alliance_with" do
+      it "returns nil if no alliance exists" do
+        expect(organization.alliance_with(other_organization)).to be_nil
+      end
+
+      it "returns alliance when organization is source" do
+        alliance = OrganizationAlliance.create!(
+          source_organization: organization,
+          target_organization: other_organization
+        )
+
+        expect(organization.alliance_with(other_organization)).to eq(alliance)
+      end
+
+      it "returns alliance when organization is target" do
+        alliance = OrganizationAlliance.create!(
+          source_organization: other_organization,
+          target_organization: organization
+        )
+
+        expect(organization.alliance_with(other_organization)).to eq(alliance)
+      end
+    end
+
+    describe "alliance status methods" do
+      let(:third_organization) { Fabricate(:organization) }
+
+      before do
+        @pending_sent = OrganizationAlliance.create!(
+          source_organization: organization,
+          target_organization: other_organization,
+          status: "pending"
+        )
+
+        @pending_received = OrganizationAlliance.create!(
+          source_organization: third_organization,
+          target_organization: organization,
+          status: "pending"
+        )
+
+        @accepted_sent = OrganizationAlliance.create!(
+          source_organization: organization,
+          target_organization: Fabricate(:organization),
+          status: "accepted"
+        )
+
+        @accepted_received = OrganizationAlliance.create!(
+          source_organization: Fabricate(:organization),
+          target_organization: organization,
+          status: "accepted"
+        )
+
+        @rejected_sent = OrganizationAlliance.create!(
+          source_organization: organization,
+          target_organization: Fabricate(:organization),
+          status: "rejected"
+        )
+
+        @rejected_received = OrganizationAlliance.create!(
+          source_organization: Fabricate(:organization),
+          target_organization: organization,
+          status: "rejected"
+        )
+      end
+
+      it "returns pending sent alliances" do
+        expect(organization.pending_sent_alliances).to include(@pending_sent)
+        expect(organization.pending_sent_alliances).not_to include(@pending_received)
+      end
+
+      it "returns pending received alliances" do
+        expect(organization.pending_received_alliances).to include(@pending_received)
+        expect(organization.pending_received_alliances).not_to include(@pending_sent)
+      end
+
+      it "returns accepted alliances" do
+        expect(organization.accepted_alliances).to include(@accepted_sent, @accepted_received)
+        expect(organization.accepted_alliances).not_to include(
+          @pending_sent, @pending_received, @rejected_sent, @rejected_received
+        )
+      end
+
+      it "returns rejected alliances" do
+        expect(organization.rejected_alliances).to include(@rejected_sent, @rejected_received)
+        expect(organization.rejected_alliances).not_to include(
+          @pending_sent, @pending_received, @accepted_sent, @accepted_received
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION


https://github.com/user-attachments/assets/a6554c76-d335-4587-827c-238a1d2c33b9

## Alliance Feature for Time Banks

This new feature that allows time banks to establish alliances with each other. This functionality extends the existing organization relationship model to enable time banks to collaborate more effectively.

The implementation includes:

- A migration to create the `organization_alliances` table which tracks relationships between time banks.Only organization administrators can manage alliances.

- New models and controllers to manage the alliance lifecycle (request, accept/reject, end alliance).

- UI components integrated into the existing organizations views, allowing administrators to:
  - Request alliances with other time banks
  - Accept or reject incoming alliance requests
  - View and manage their current alliances
  - End active alliances when needed
 
- Several tests  to ensure the functionality works as expected.




