### PR TITLE
Inter-organizational Contact and Time Transfers

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -6,7 +6,9 @@ class OffersController < PostsController
   def show
     super
 
-    member = @offer.user.members.find_by(organization: current_organization)
-    @destination_account = member.account if member
+    if @offer.user
+      member = @offer.user.members.find_by(organization: current_organization)
+      @destination_account = member.account if member
+    end
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -65,6 +65,19 @@ class PostsController <  ApplicationController
     redirect_to send("#{resources}_path") if post.update!(active: false)
   end
 
+  def contact
+    @post = Post.find(params[:id])
+
+    if current_user && current_organization != @post.organization && current_user.active?(current_organization)
+      OrganizationNotifier.contact_request(@post, current_user, current_organization).deliver_now
+      flash[:notice] = t('posts.contact.success')
+    else
+      flash[:error] = t('posts.contact.error')
+    end
+
+    redirect_to @post
+  end
+
   private
 
   def resource

--- a/app/mailers/organization_notifier.rb
+++ b/app/mailers/organization_notifier.rb
@@ -56,4 +56,18 @@ class OrganizationNotifier < ActionMailer::Base
       )
     end
   end
+
+  def contact_request(post, requester, requester_organization)
+    @post = post
+    @requester = requester
+    @requester_organization = requester_organization
+    @offerer = post.user
+
+    I18n.with_locale(@offerer.locale) do
+      mail(
+        to: @offerer.email,
+        subject: t('organization_notifier.contact_request.subject', post: @post.title)
+      )
+    end
+  end
 end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -63,4 +63,22 @@ class Transfer < ApplicationRecord
     return unless source == destination
     errors.add(:base, :same_account)
   end
+
+  def cross_bank?
+    movements.count > 2
+  end
+
+  def related_account_for(movement)
+    return nil unless movement.transfer == self
+
+    movements_in_order = movements.order(:id)
+    current_index = movements_in_order.index(movement)
+    return nil unless current_index
+
+    if movement.amount > 0 && current_index > 0
+      movements_in_order[current_index - 1].account
+    elsif movement.amount < 0 && current_index < movements_in_order.length - 1
+      movements_in_order[current_index + 1].account
+    end
+  end
 end

--- a/app/models/transfer_factory.rb
+++ b/app/models/transfer_factory.rb
@@ -1,24 +1,41 @@
 class TransferFactory
-  def initialize(current_organization, current_user, offer_id, destination_account_id)
+  def initialize(current_organization, current_user, offer_id, destination_account_id = nil, cross_bank = false)
     @current_organization = current_organization
     @current_user = current_user
     @offer_id = offer_id
     @destination_account_id = destination_account_id
+    @cross_bank = cross_bank
   end
 
   # Returns the offer that is the subject of the transfer
   #
   # @return [Maybe<Offer>]
   def offer
-    current_organization.offers.find_by_id(offer_id)
+    if offer_id.present?
+      Offer.find_by_id(offer_id)
+    end
   end
 
   # Returns a new instance of Transfer with the data provided
   #
   # @return [Transfer]
   def build_transfer
-    transfer = Transfer.new(source: source, destination: destination_account.id)
-    transfer.post = offer unless for_organization?
+    transfer = Transfer.new(source: source)
+
+    if cross_bank && offer && offer.organization != current_organization
+      transfer.destination = destination_organization_account.id
+      transfer.post = offer
+      transfer.is_cross_bank = true
+      transfer.meta = {
+        source_organization_id: current_organization.id,
+        destination_organization_id: offer.organization.id,
+        final_destination_user_id: offer.user.id
+      }
+    else
+      transfer.destination = destination_account.id
+      transfer.post = offer unless for_organization?
+    end
+
     transfer
   end
 
@@ -32,49 +49,50 @@ class TransferFactory
   end
 
   def accountable
-    @accountable ||= destination_account.accountable
+    @accountable ||= destination_account.try(:accountable)
   end
 
   private
 
   attr_reader :current_organization, :current_user, :offer_id,
-              :destination_account_id
+              :destination_account_id, :cross_bank
 
   # Returns the id of the account that acts as source of the transfer.
   # Either the account of the organization or the account of the current user.
   #
   # @return [Maybe<Integer>]
   def source
-    organization = if accountable.is_a?(Organization)
-                     accountable
-                   else
-                     current_organization
-                   end
-
-    current_user.members.find_by(organization: organization).account.id
+    current_user.members.find_by(organization: current_organization).account.id
   end
 
   # Checks whether the destination account is an organization
   #
   # @return [Boolean]
   def for_organization?
-    destination_account.accountable.class == Organization
+    destination_account.try(:accountable).class == Organization
   end
 
   def admin?
     current_user.try :manages?, current_organization
   end
 
-  # TODO: this method implements authorization by scoping the destination
-  # account in all the accounts of the current organization. If the specified
-  # destination account does not belong to it, the request will simply faily.
+  # Returns the account of the target organization for cross-bank transfers
   #
+  # @return [Account]
+  def destination_organization_account
+    offer.organization.account
+  end
+
   # Returns the account the time will be transfered to
   #
   # @return [Account]
   def destination_account
-    @destination_account ||= current_organization
-      .all_accounts
-      .find(destination_account_id)
+    @destination_account ||= if destination_account_id
+      current_organization.all_accounts.find(destination_account_id)
+    elsif offer
+      # Get the destination account from the offer's user
+      member = offer.user.members.find_by(organization: offer.organization)
+      member.account if member
+    end
   end
 end

--- a/app/views/inquiries/show.html.erb
+++ b/app/views/inquiries/show.html.erb
@@ -4,5 +4,17 @@
       <%= render 'shared/post_actions', post: @inquiry %>
     <% end %>
   </div>
+<% else %>
+  <div class="actions text-end">
+    <% if current_user && current_user.active?(current_organization) %>
+      <%= link_to contact_inquiry_path(@inquiry), 
+                  method: :post,
+                  data: { confirm: t('posts.show.contact_confirmation') },
+                  class: "btn btn-primary" do %>
+        <%= glyph :envelope %>
+        <%= t 'posts.show.request_contact' %>
+      <% end %>
+    <% end %>
+  </div>
 <% end %>
 <%= render "shared/post", post: @inquiry %>

--- a/app/views/offers/show.html.erb
+++ b/app/views/offers/show.html.erb
@@ -4,8 +4,31 @@
       <%= render 'shared/post_actions', post: @offer %>
     <% end %>
     <% if current_user and @offer.user != current_user %>
+      <% if current_organization != @offer.organization && current_user.active?(current_organization) %>
+        <%= link_to t('posts.show.request_contact'),
+          contact_post_path(@offer),
+          method: :post,
+          class: "btn btn-info" %>
+      <% end %>
       <%= link_to new_transfer_path(id: @offer.user.id, offer: @offer.id, destination_account_id: @destination_account.id),
                   class: "btn btn-success" do %>
+        <%= glyph :time %>
+        <%= t ".give_time_for" %>
+      <% end %>
+    <% end %>
+  </div>
+<% else %>
+  <div class="actions text-end">
+    <% if current_user && current_user.active?(current_organization) %>
+      <% if current_organization != @offer.organization %>
+        <%= link_to t('posts.show.request_contact'),
+          contact_post_path(@offer),
+          method: :post,
+          data: { confirm: t('posts.show.contact_confirmation') },
+          class: "btn btn-primary me-2" %>
+      <% end %>
+      <%= link_to new_transfer_path(id: @offer.user.id, offer: @offer.id, cross_bank: true),
+                class: "btn btn-success" do %>
         <%= glyph :time %>
         <%= t ".give_time_for" %>
       <% end %>

--- a/app/views/organization_notifier/contact_request.html.erb
+++ b/app/views/organization_notifier/contact_request.html.erb
@@ -1,0 +1,26 @@
+<%= t('organization_notifier.contact_request.greeting', name: @offerer.username) %>
+
+<%= t('organization_notifier.contact_request.message',
+          requester: @requester.username,
+          organization: @requester_organization.name,
+          post: @post.title) %>
+
+<%= t('organization_notifier.contact_request.requester_info') %>:
+
+
+  <%= t('activerecord.attributes.user.username') %>: <%= @requester.username %>
+  <% if @requester.has_valid_email? %>
+    <%= t('activerecord.attributes.user.email') %>: <%= @requester.email %>
+  <% end %>
+  <% phones = [@requester.phone, @requester.alt_phone].select(&:present?) %>
+  <% if phones.present? %>
+    <%= t('users.show.phone', count: phones.size) %>:
+      <% phones.each_with_index do |phone, index| %>
+        <%= " — " if index != 0 %>
+        <%= phone %>
+      <% end %>
+    
+  <% end %>
+
+
+<%= t('organization_notifier.contact_request.closing') %>

--- a/app/views/shared/_movements.html.erb
+++ b/app/views/shared/_movements.html.erb
@@ -20,20 +20,29 @@
               <%= l mv.created_at.to_date, format: :long %>
             </td>
             <td>
-              <% mv.other_side.account.tap do |account| %>
-                <% if account.accountable.present? %>
-                  <% if account.accountable_type == "Organization" %>
-                    <%= link_to account,
-                        organization_path(account.accountable) %>
-                  <% elsif account.accountable.active %>
-                    <%= link_to account.accountable.display_name_with_uid,
-                        user_path(account.accountable.user) %>
-                  <% else %>
-                    <%= t("users.show.inactive_user") %>
-                  <% end %>
+              <%
+                display_account = nil
+                
+                if mv.transfer&.cross_bank?
+                  display_account = mv.transfer.related_account_for(mv)
+                  display_account ||= mv.other_side.account
+                else
+                  display_account = mv.other_side.account
+                end
+              %>
+              
+              <% if display_account.accountable.present? %>
+                <% if display_account.accountable_type == "Organization" %>
+                  <%= link_to display_account,
+                      organization_path(display_account.accountable) %>
+                <% elsif display_account.accountable.active %>
+                  <%= link_to display_account.accountable.display_name_with_uid,
+                      user_path(display_account.accountable.user) %>
                 <% else %>
-                  <%= t("users.show.deleted_user") %>
+                  <%= t("users.show.inactive_user") %>
                 <% end %>
+              <% else %>
+                <%= t("users.show.deleted_user") %>
               <% end %>
             </td>
             <td>

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -69,13 +69,21 @@
     </div>
   </div>
 </div>
-<% if !current_user || post.organization != current_organization || !current_user.active?(current_organization) %>
+
+<% if current_user && post.organization != current_organization && current_user.active?(current_organization) %>
+  <div class="alert alert-info">
+    <%= t 'posts.show.contact_info_hidden',
+      type: post.class.model_name.human,
+      organization: post.organization.name %>
+  </div>
+<% elsif !current_user || post.organization != current_organization || !current_user.active?(current_organization) %>
   <div class="alert alert-info">
     <%= t 'posts.show.info',
       type: post.class.model_name.human,
       organization: post.organization.name %>
   </div>
 <% end %>
+
 <% unless current_user %>
   <div class="alert alert-info">
     <%= link_to t("layouts.application.login"),

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -71,13 +71,13 @@
 </div>
 
 <% if current_user && post.organization != current_organization && current_user.active?(current_organization) %>
-  <div class="alert alert-info">
+  <div class="alert bg-info">
     <%= t 'posts.show.contact_info_hidden',
       type: post.class.model_name.human,
       organization: post.organization.name %>
   </div>
 <% elsif !current_user || post.organization != current_organization || !current_user.active?(current_organization) %>
-  <div class="alert alert-info">
+  <div class="alert bg-info">
     <%= t 'posts.show.info',
       type: post.class.model_name.human,
       organization: post.organization.name %>
@@ -85,7 +85,7 @@
 <% end %>
 
 <% unless current_user %>
-  <div class="alert alert-info">
+  <div class="alert bg-info">
     <%= link_to t("layouts.application.login"),
       new_user_session_path,
       class: "btn btn-primary" %>

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -6,7 +6,7 @@
 <% if offer %>
   <h3><%= offer %></h3>
   <% if cross_bank %>
-    <div class="alert alert-info">
+    <div class="alert bg-info">
       <%= t 'transfers.cross_bank.info', organization: offer.organization.name %>
     </div>
   <% end %>

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -1,10 +1,17 @@
 <h1>
   <small><%= t ".give_time" %></small>
-  <%= link_to accountable.display_name_with_uid, accountable_path(accountable) %>
+  <%= link_to accountable.try(:display_name_with_uid) || offer.user.username, accountable_path(accountable) || offer.user %>
 </h1>
+
 <% if offer %>
   <h3><%= offer %></h3>
+  <% if cross_bank %>
+    <div class="alert alert-info">
+      <%= t 'transfers.cross_bank.info', organization: offer.organization.name %>
+    </div>
+  <% end %>
 <% end %>
+
 <%= simple_form_for transfer do |f| %>
   <div class="form-inputs">
     <%= f.input :hours,
@@ -24,7 +31,13 @@
                 } %>
     <%= f.input :amount, as: :hidden %>
     <%= f.input :reason %>
-    <%= f.input :destination, as: :hidden %>
+    
+    <% if cross_bank %>
+      <%= hidden_field_tag :cross_bank, "true" %>
+      <%= hidden_field_tag :post_id, offer.id %>
+    <% else %>
+      <%= f.input :destination, as: :hidden %>
+    <% end %>
 
     <% if sources.present? %>
       <div class="mb-3">
@@ -38,7 +51,9 @@
       </div>
     <% end %>
 
-    <%= render partial: "#{accountable.model_name.singular}_offer", locals: { form: f, offer: offer, accountable: accountable } %>
+    <% unless cross_bank %>
+      <%= render partial: "#{accountable.model_name.singular}_offer", locals: { form: f, offer: offer, accountable: accountable } %>
+    <% end %>
   </div>
 
   <div class="form-actions">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -408,6 +408,12 @@ en:
       subject: Newsletter
       text1: 'Latest offers published:'
       text2: 'Latest requests published:'
+    contact_request:
+      subject: "Contact request for your %{post}"
+      greeting: "Hello %{name},"
+      message: "%{requester} from %{organization} time bank is interested in your %{post}."
+      requester_info: "Here is their contact information"
+      closing: "If you are interested, please contact them directly using the provided information."
   organizations:
     give_time:
       give_time: Give time to
@@ -468,6 +474,12 @@ en:
   posts:
     show:
       info: This %{type} belongs to %{organization}.
+      contact_info_hidden: "Contact information is not visible as this %{type} is from %{organization} time bank. Click 'Request Contact' to connect with the member."
+      request_contact: "Request Contact"
+      contact_confirmation: "If you confirm, your contact information will be sent by email to the person offering this service. Do you want to proceed?"
+    contact:
+      success: "Contact request sent successfully. The offerer will receive your contact information by email."
+      error: "Unable to send contact request."
   reports:
     download: Download
     download_all: Download all
@@ -555,6 +567,9 @@ en:
         other: "%{count} minutes"
     new:
       error_amount: Time must be greater than 0
+    cross_bank:
+      info: "This is a time transfer to a member who belongs to another organization. The time will be transferred through both organizations."
+      success: "Cross-organization transfer completed successfully."
   users:
     avatar:
       change_your_image: Change your image

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -474,7 +474,7 @@ en:
   posts:
     show:
       info: This %{type} belongs to %{organization}.
-      contact_info_hidden: "Contact information is not visible as this %{type} is from %{organization} time bank. Click 'Request Contact' to connect with the member."
+      contact_info_hidden: "Contact information is not visible because this %{type} belongs to %{organization}. Click the ‘Request Contact’ button to connect with the member."
       request_contact: "Request Contact"
       contact_confirmation: "If you confirm, your contact information will be sent by email to the person offering this service. Do you want to proceed?"
     contact:
@@ -568,7 +568,7 @@ en:
     new:
       error_amount: Time must be greater than 0
     cross_bank:
-      info: "This is a time transfer to a member who belongs to another organization. The time will be transferred through both organizations."
+      info: "This is a time transfer to a member who belongs to %{organization}. The time will be transferred through both organizations."
       success: "Cross-organization transfer completed successfully."
   users:
     avatar:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -408,6 +408,12 @@ es:
       subject: Boletín semanal
       text1: 'Últimas ofertas publicadas:'
       text2: 'Últimas demandas publicadas:'
+    contact_request:
+      subject: "Solicitud de contacto para tu %{post}"
+      greeting: "Hola %{name},"
+      message: "%{requester} del banco de tiempo %{organization} está interesado/a en tu %{post}."
+      requester_info: "Aquí está su información de contacto"
+      closing: "Si estás interesado/a, por favor contáctale directamente usando la información proporcionada."
   organizations:
     give_time:
       give_time: Dar Tiempo a
@@ -468,6 +474,12 @@ es:
   posts:
     show:
       info: Esta %{type} pertenece a %{organization}.
+      contact_info_hidden: "La información de contacto no es visible ya que esta %{type} es del banco de tiempo %{organization}. Haz clic en 'Solicitar Contacto' para conectar con el miembro."
+      request_contact: "Solicitar Contacto"
+      contact_confirmation: "Si confirmas, tu información de contacto será enviada por correo electrónico a la persona que ofrece este servicio. ¿Deseas continuar?"
+    contact:
+      success: "Solicitud de contacto enviada correctamente. El ofertante recibirá tu información de contacto por correo electrónico."
+      error: "No se pudo enviar la solicitud de contacto."
   reports:
     download: Descargar
     download_all: Descargar todo
@@ -555,6 +567,9 @@ es:
         other: "%{count} minutos"
     new:
       error_amount: 'El tiempo debe ser mayor que 0 '
+    cross_bank:
+      info: "Esta es una transferencia de tiempo a un miembro perteneciente a otra organización. El tiempo se transferirá a través de ambas organizaciones."
+      success: "Transferencia entre organizaciones completada con éxito."
   users:
     avatar:
       change_your_image: Cambia tu imagen

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -474,7 +474,7 @@ es:
   posts:
     show:
       info: Esta %{type} pertenece a %{organization}.
-      contact_info_hidden: "La información de contacto no es visible ya que esta %{type} es del banco de tiempo %{organization}. Haz clic en 'Solicitar Contacto' para conectar con el miembro."
+      contact_info_hidden: "La información de contacto no es visible debido a que esta %{type} pertenece a %{organization}. Haga clic en el botón 'Solicitar Contacto' para conectar con el miembro."
       request_contact: "Solicitar Contacto"
       contact_confirmation: "Si confirmas, tu información de contacto será enviada por correo electrónico a la persona que ofrece este servicio. ¿Deseas continuar?"
     contact:
@@ -568,7 +568,7 @@ es:
     new:
       error_amount: 'El tiempo debe ser mayor que 0 '
     cross_bank:
-      info: "Esta es una transferencia de tiempo a un miembro perteneciente a otra organización. El tiempo se transferirá a través de ambas organizaciones."
+      info: "Esta es una transferencia de tiempo a un miembro perteneciente a %{organization}. El tiempo se transferirá a través de ambas organizaciones."
       success: "Transferencia entre organizaciones completada con éxito."
   users:
     avatar:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,8 +20,13 @@ Rails.application.routes.draw do
 
   get "/pages/:page" => "pages#show", as: :page
 
-  resources :offers
-  resources :inquiries
+  concern :contactable do
+    post :contact, on: :member
+  end
+
+  resources :offers, concerns: :contactable
+  resources :inquiries, concerns: :contactable
+  resources :posts, concerns: :contactable
   resources :device_tokens, only: :create
 
   concern :accountable do

--- a/db/migrate/20250418100031_add_cross_bank_fields_to_transfers.rb
+++ b/db/migrate/20250418100031_add_cross_bank_fields_to_transfers.rb
@@ -1,0 +1,5 @@
+class AddCrossBankFieldsToTransfers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :transfers, :meta, :jsonb, default: {}, null: false
+  end
+end


### PR DESCRIPTION


https://github.com/user-attachments/assets/fbd567db-5463-4829-8837-85bbbe75cbcd

This pull request introduces contact and time transfers between organizations, fixes how movements derived from these flows are displayed, and adds clear messaging for users. The goal is to allow members of different time banks to collaborate without exposing private data while keeping hour accounting balanced on both sides. The changes span controllers, models, views, routes, locales, and a database migration.

## Organization-to-Organization Contact

- **New `contact` action in PostsController**: Allows a member of another organization to request the offerer's email; the request is authorized only if the requester is active in their bank and the offer is not from their own organization.

- **"Request contact" button** added to offers and inquiries views when the visitor meets the above conditions.

- **Help text**: Includes a banner explaining that contact data is not visible and guides the user to use the button.

- **Reusable route**: The action is declared as `post :contact, on: :member` and added via concern to offers, inquiries, and posts, maintaining consistency with existing convention.

- **Purpose**: Facilitate collaboration between organizations without exposing emails or phone numbers and without breaking the current publication flow.

## Cross-Bank Transfers

- **TransferFactory**
  - Adds `cross_bank` flag and stores metadata (`source_organization_id`, `destination_organization_id`, `final_destination_user_id`) in meta.
  - Determines the correct destination account based on whether the transfer is cross-bank or internal.

- **Transfer**
  - New `make_cross_bank_movements` method that generates the 6 movements needed for the User A → Bank A → Bank B → User B flow, keeping the balance at zero in each organization.
  - Helper `related_account_for` used by the movements view to show the real counterpart in each entry.

- **TransfersController**
  - Auxiliary action `create_cross_bank_transfer` that encapsulates the logic and simplifies the `create` action.
  - The `transfers/new` view displays an informative banner when `@cross_bank` is true.

- **Migration `20250418100031_add_cross_bank_fields_to_transfers.rb`**
  - Adds two columns (`is_cross_bank` and `meta`) and an index to the transfers table to manage inter-bank transfers and facilitate analytical reports.
  - `is_cross_bank` (boolean, default: false) indicates if the transfer involves multiple organizations.
  - The `meta` field (jsonb) stores additional details such as organization and end-user identifiers.
  - The `index_transfers_on_is_cross_bank` index optimizes frequent queries.

- **Purpose**: Explicitly record inter-bank transfers, provide transparency to users, and maintain correct accounting on both sides.

## Movement View Improvements

- **`_movements.html.erb`** now invokes `related_account_for` when the transfer is cross-bank, so each row shows the account the user expects to see (not the intermediate step).

- There are now two types of transfers:
  - **Internal**: between two members of the same time bank.
  - **Cross-bank**: between members of different banks (the new feature in this PR).

- Previously, the movements view showed the counterpart using `mv.other_side.account`
  - This works well for internal transfers, as there are only two movements (debit-credit) and the "other side" is always the receiving user.
  - For cross-bank transfers, we generate 6 movements; there `other_side` is insufficient, which is why we added `Transfer#related_account_for` and use it only if `mv.transfer.is_cross_bank` is true.
  
  - If the transfer is internal → the view continues to show `other_side.account` (historical logic).
  - If it is cross-bank → the view uses `related_account_for` so that each entry shows the account actually involved in that step of the chain.

- **Purpose**: Eliminate confusion in the movements table and promote transparency in transfers between organizations.

## Internationalization and UX

- New keys in `en.yml` and `es.yml` for buttons, banners, and flash messages.

- Minor style adjustments (`btn-primary me-2`, `bg-info`) to maintain consistency with Bootstrap.

- **Purpose**: Provide clear messages in both official languages and maintain the project's visual style.