### PR TITLE
fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN RAILS_ENV=production \
     SECRET_KEY_BASE=dummy \
     RAILS_MASTER_KEY=dummy \
     DB_ADAPTER=nulldb \
+    ASSETS_PRECOMPILE=true \
+    STORAGE_PROVIDER=local \
     bundle exec rails assets:precompile
 
 RUN mv config/credentials.yml.enc.bak config/credentials.yml.enc 2>/dev/null || true

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'select2-rails', '~> 4.0.13'
 
 group :production do
   # we are using an ExecJS runtime only on the precompilation phase
-  gem "uglifier", "~> 4.2.0", require: false
+  gem "terser", "~> 1.2", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,6 +455,8 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     stringio (3.1.5)
+    terser (1.2.5)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     tilt (2.5.0)
     timeout (0.4.3)
@@ -462,8 +464,6 @@ GEM
       bigdecimal (~> 3.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.1)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -534,7 +534,7 @@ DEPENDENCIES
   sidekiq-cron (~> 1.12.0)
   simple_form (~> 5.0.2)
   simplecov (~> 0.22)
-  uglifier (~> 4.2.0)
+  terser (~> 1.2)
   web-console (~> 4.2)
 
 BUNDLED WITH

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 # Uglifier is only used on the precompile phase, so we can require it conditionally
-require "uglifier" if ENV["SECRET_KEY_BASE"] == "dummy"
+require "terser" if ENV["ASSETS_PRECOMPILE"] == "true"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -28,8 +28,8 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress CSS & JS using preprocessors only on the precompile phase
-  if ENV["SECRET_KEY_BASE"] == "dummy"
-    config.assets.js_compressor = Uglifier.new(harmony: true)
+  if ENV["ASSETS_PRECOMPILE"] == "true"
+    config.assets.js_compressor = Terser.new
     config.assets.css_compressor = :sass
   end
 


### PR DESCRIPTION
The following error shows up when running `docker build .` when precompiling assets.

```
------
 > [builder 18/21] RUN RAILS_ENV=production     SECRET_KEY_BASE=dummy     RAILS_MASTER_KEY=dummy     DB_ADAPTER=nulldb     bundle exec rails assets:precompile:
2.692 Error retrieving instance profile credentials: Failed to open TCP connection to 169.254.169.254:80 (execution expired)
2.700 bin/rails aborted!
2.700 Aws::Errors::MissingRegionError: No region was provided. Configure the `:region` option or export the region name to ENV['AWS_REGION'] (Aws::Errors::MissingRegionError)
2.700
2.700         raise Errors::MissingRegionError if region.nil? || region == ''
2.700               ^^^^^^^^^^^^^^^^^^^^^^^^^^
2.700 /app/app/models/user.rb:26:in `<class:User>'
2.700 /app/app/models/user.rb:1:in `<main>'
2.700 /app/config/routes.rb:11:in `block in <main>'
2.700 /app/config/routes.rb:4:in `<main>'
2.700 /app/config/environment.rb:5:in `<main>'
2.700 Tasks: TOP => environment
2.700 (See full trace by running task with --trace)
------
```

This is fixed by adding `STORAGE_PROVIDER=local`, since ActiveStorage is not needed at that point. This seems to be a [bug in ActiveStorage](https://github.com/rails/rails/pull/54142) that is fixed in future Rails versions.

After this is fixed, the folowing error shows up:

```
 > [builder 18/21] RUN RAILS_ENV=production     SECRET_KEY_BASE=dummy     RAILS_MASTER_KEY=dummy     DB_ADAPTER=nulldb     STORAGE_PROVIDER=local     bundle exec rails assets:precompile:
5.471 bin/rails aborted!
5.471 Uglifier::Error:  (Uglifier::Error)
5.471
5.471 Tasks: TOP => assets:precompile
5.471 (See full trace by running task with --trace)
------
```

This is fixed by replacing [uglifier](https://github.com/lautis/uglifier) with [terser](https://github.com/ahorek/terser-ruby), which accepts modern JS syntax and seems more actively maintained.