### PR TITLE
feat: allow default locale to be set via DEFAULT_LOCALE env var

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ module Timeoverflow
     config.load_defaults 7.2
 
     # I18n configuration
-    config.i18n.default_locale = :es
+    config.i18n.default_locale = ENV.fetch('DEFAULT_LOCALE', 'es').to_sym
     config.i18n.available_locales = [:es, :ca, :eu, :gl, :en, :'pt-BR', :fr, :ja]
     config.i18n.fallbacks = true
 


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `:es` default locale with `ENV.fetch('DEFAULT_LOCALE', 'es').to_sym`
- Defaults to `es` when the env var is not set, so no behaviour change for existing deployments
- Consistent with the existing `ALLOWED_HOSTS` pattern in the same file

Resolves #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)